### PR TITLE
Add refresh token from bitbucket to db

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -113,6 +113,7 @@ const createUserUpdateObj = (user: User, account: Account | null, db_user?: DbUs
 					scope: account.scope,
 					access_token: account.access_token,
 					expires_at: account.expires_at,
+					refresh_token: account.refresh_token,
 				}
 			}
 		}


### PR DESCRIPTION
- [x] Tested locally, db insertion succesful, see users table `id = 7` for how refresh_token is stored
- [x] No changes need for merging/vercel deployment