### PR TITLE
session infinite call bug fix

### DIFF
--- a/components/LoginLogout.tsx
+++ b/components/LoginLogout.tsx
@@ -15,31 +15,33 @@ export default function LoginLogout() {
 
 	// FIXME: Ideally, this should have been automatically accomplished using useSession provided by NextAuth. But that is not working.
 	useEffect(() => {
-		const anonymousId = getAndSetAnonymousIdFromLocalStorage()
 		fetch("/api/auth/session", { cache: "no-store" }).then(async (res) => {
 			const sessionVal = await res.json();
 			setSession(sessionVal);
 		});
+	}, [])
+
+	useEffect(() => {
+		const anonymousId = getAndSetAnonymousIdFromLocalStorage()
 
 		const handleLogoutClick = () => {
-			rudderEventMethods?.track(getAuthUserId(session), "Logout link clicked", { type: "link", eventStatusFlag: 1, source: "profile popup", name: getAuthUserName(session)}, anonymousId)
+			rudderEventMethods?.track(getAuthUserId(session), "Logout link clicked", { type: "link", eventStatusFlag: 1, source: "profile popup", name: getAuthUserName(session) }, anonymousId)
 		};
-		
+
 		const handleContributeClick = () => {
-			rudderEventMethods?.track(getAuthUserId(session), "Contribute link clicked", { type: "link", eventStatusFlag: 1, source: "profile-popup", name: getAuthUserName(session)}, anonymousId)
+			rudderEventMethods?.track(getAuthUserId(session), "Contribute link clicked", { type: "link", eventStatusFlag: 1, source: "profile-popup", name: getAuthUserName(session) }, anonymousId)
 		};
 
 		const handleSettingsClick = () => {
-			rudderEventMethods?.track(getAuthUserId(session), "Settings link clicked", { type: "link", eventStatusFlag: 1, source: "profile-popup", name: getAuthUserName(session)}, anonymousId)
+			rudderEventMethods?.track(getAuthUserId(session), "Settings link clicked", { type: "link", eventStatusFlag: 1, source: "profile-popup", name: getAuthUserName(session) }, anonymousId)
 		};
 
-	
 		const logoutLink = document.getElementById('logout-link');
-  		const contributeLink = document.getElementById('contribute-link');
+		const contributeLink = document.getElementById('contribute-link');
 		const settingsLink = document.getElementById('settings-link')
 
-  		logoutLink?.addEventListener('click', handleLogoutClick);
-  		contributeLink?.addEventListener('click', handleContributeClick);
+		logoutLink?.addEventListener('click', handleLogoutClick);
+		contributeLink?.addEventListener('click', handleContributeClick);
 		settingsLink?.addEventListener('click', handleSettingsClick);
 
 		return () => {
@@ -64,7 +66,7 @@ export default function LoginLogout() {
 					<li id='settings-link' className='border-b-2 border-b-gray-200 p-2 text-center'>
 						<Link href='/settings' className='cursor-pointer w-full'>Settings</Link>
 					</li>
-					<li id='logout-link' className='p-2 text-center cursor-pointer' onClick={() => (logout(getAuthUserId(session), getAuthUserName(session), getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods?rudderEventMethods:null)))}>
+					<li id='logout-link' className='p-2 text-center cursor-pointer' onClick={() => (logout(getAuthUserId(session), getAuthUserName(session), getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods ? rudderEventMethods : null)))}>
 						Logout
 					</li>
 				</ol>
@@ -74,7 +76,7 @@ export default function LoginLogout() {
 		</>
 	)
 	else return (
-		<Button variant='contained' onClick={() => (login(getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods?rudderEventMethods:null)))} className="rounded bg-inherit sm:bg-primary-main text-secondary-main py-2 px-4 font-semibold">
+		<Button variant='contained' onClick={() => (login(getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods ? rudderEventMethods : null)))} className="rounded bg-inherit sm:bg-primary-main text-secondary-main py-2 px-4 font-semibold">
 			Login/Signup
 		</Button>
 	)

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -89,7 +89,9 @@ export const authOptions = {
 		},
 		async session({ session }: { session: Session }) {
 			if (session && session.user) {
-				const usersWithAlias = await getUserByAlias(session.user.email!)
+				const usersWithAlias = await getUserByAlias(session.user.email!).catch(err => {
+					console.error(`[session callback] getUserByAlias failed for ${session.user.email}`, err);
+				})
 				if (!usersWithAlias || usersWithAlias.length < 1) {
 					console.warn(`[session callback] No user found with this email: ${session.user.email}`);
 				}

--- a/utils/db/users.ts
+++ b/utils/db/users.ts
@@ -33,9 +33,11 @@ export const getUserByAlias = async (alias_email: string): Promise<DbUser[] | un
 	const user_alias_search_q = `SELECT *
 		FROM users
 		WHERE '${alias_email}' = ANY(aliases)`;
-	const user_alias_search_result = await conn.query(user_alias_search_q);
+	const user_alias_search_result = await conn.query(user_alias_search_q).catch(err => {
+		console.log(`[users/getUserByAlias] Query failed: Select from users where aliases contain ${alias_email}`, err);
+	});
 
-	if (user_alias_search_result.rowCount) {
+	if (user_alias_search_result && user_alias_search_result.rowCount) {
 		console.debug(`${user_alias_search_result.rowCount} user(s) exist with this email as an alias.`);
 		return user_alias_search_result.rows;
 	}


### PR DESCRIPTION
Bug: if you look at the logs on Google Cloud right now, you will see infinite logs of the form `1 user(s) exist with this email as an alias.`. There 7 such logs each second for the past multiple days. This is only printed after the database has been queried to look for a particular user (using their email alias). 

This pull request fixes that issue - there was a circular dependency in the `LoginLogout` component which was causing an infinite loop. 