### PR TITLE
Added Banner events

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -9,7 +9,7 @@ import { getAndSetAnonymousIdFromLocalStorage } from "../utils/rudderstack_initi
 import { getAuthUserId, getAuthUserName } from "../utils/auth";
 
 export type BannerHeightType = "h-12" | "h-24" | "h-32" | "h-40" | "h-44" | undefined;
-type BannerSituation = "not-installed" | "incompatible-browser" | "incompatible-device" | null;
+type BannerSituation = "extension-not-installed" | "incompatible-browser" | "incompatible-device" | null;
 
 const Banner = ({ bannerHeight, setBannerHeight }: {
 	bannerHeight: BannerHeightType,
@@ -24,7 +24,7 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 	useEffect(() => {
 		const setBanner = (situation: BannerSituation) => {
 			switch (situation) {
-				case "not-installed":
+				case "extension-not-installed":
 					setBannerHeight(() => {
 						const bannerHeight = 32;
 						setBannerHTML((<>
@@ -86,6 +86,10 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 		}
 
 		const situation = determineSituation();
+		if (situation) {
+			const anonymousId = getAndSetAnonymousIdFromLocalStorage();
+			rudderEventMethods?.track(getAuthUserId(session), situation, { type: "detection", eventStatusFlag: 0, source: "banner", name: getAuthUserName(session) }, anonymousId);
+		}
 		setBanner(situation);
 	}, [setBannerHeight])
 
@@ -93,7 +97,7 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 		const anonymousId = getAndSetAnonymousIdFromLocalStorage()
 
 		const handleDownloadClick = () => {
-			rudderEventMethods?.track(getAuthUserId(session), "Add to chrome button", { type: "link", eventStatusFlag: 1, source: "navbar", name: getAuthUserName(session) }, anonymousId)
+			rudderEventMethods?.track(getAuthUserId(session), "Add to chrome button", { type: "link", eventStatusFlag: 1, source: "banner", name: getAuthUserName(session) }, anonymousId)
 		};
 		const downloadLink = document.getElementById('add-to-chrome-btn');
 		downloadLink?.addEventListener('click', handleDownloadClick);

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -9,7 +9,7 @@ import { getAndSetAnonymousIdFromLocalStorage } from "../utils/rudderstack_initi
 import { getAuthUserId, getAuthUserName } from "../utils/auth";
 
 export type BannerHeightType = "h-12" | "h-24" | "h-32" | "h-40" | "h-44" | undefined;
-type BannerSituation = "extension-not-installed" | "incompatible-browser" | "incompatible-device" | null;
+type BannerSituation = "extension-not-installed" | "incompatible-browser" | "incompatible-device" | null; // DO NOT EDIT THESE NAMES (They are also the name of the events)
 
 const Banner = () => {
 	const { rudderEventMethods } = React.useContext(RudderContext);

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -2,6 +2,11 @@ import Image from "next/image";
 import React, { useEffect, useState } from "react";
 import Button from '../components/Button';
 import chromeLogo from '../public/chrome-logo.png'
+import { useSession } from "next-auth/react";
+import type { Session } from "next-auth";
+import RudderContext from "./RudderContext";
+import { getAndSetAnonymousIdFromLocalStorage } from "../utils/rudderstack_initialize";
+import { getAuthUserId, getAuthUserName } from "../utils/auth";
 
 export type BannerHeightType = "h-12" | "h-24" | "h-32" | "h-40" | "h-44" | undefined;
 type BannerSituation = "not-installed" | "incompatible-browser" | "incompatible-device" | null;
@@ -10,6 +15,9 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 	bannerHeight: BannerHeightType,
 	setBannerHeight: React.Dispatch<React.SetStateAction<BannerHeightType>>
 }) => {
+	const { rudderEventMethods } = React.useContext(RudderContext);
+	const session: Session | null = useSession().data;
+
 	const chromeExtensionLink = "https://chrome.google.com/webstore/detail/vibinex/jafgelpkkkopeaefadkdjcmnicgpcncc";
 	const [bannerHTML, setBannerHTML] = useState((<></>));
 
@@ -48,8 +56,8 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 					setBannerHeight(() => {
 						const bannerHeight = 12;
 						setBannerHTML((<>
-							<p className='text-center text-sm sm:text-xl w-fit sm:max-w-1/2 h-fit my-auto'>
-								Browser extensions are not supported on this device.
+							<p className='text-center text-sm sm:text-xl w-fit sm:max-w-1/2 h-fit my-auto p-1'>
+								Browser extensions are not supported on this device. Try Vibinex on a laptop or a desktop computer.
 							</p>
 						</>))
 						return `h-${bannerHeight}`;
@@ -66,19 +74,34 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 		}
 
 		const determineSituation = (): BannerSituation => {
-            const isUnsupportedDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+			const isUnsupportedDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 			// currently, this is the best way to check if browser extensions are supported. Ref: https://stackoverflow.com/a/60927213/4677052
 			if ('chrome' in window && !isUnsupportedDevice) {
 				return null;
 			} else if (isUnsupportedDevice) {
-                return "incompatible-device";
-            } else {
+				return "incompatible-device";
+			} else {
 				return "incompatible-browser";
 			}
 		}
+
 		const situation = determineSituation();
 		setBanner(situation);
 	}, [setBannerHeight])
+
+	useEffect(() => {
+		const anonymousId = getAndSetAnonymousIdFromLocalStorage()
+
+		const handleDownloadClick = () => {
+			rudderEventMethods?.track(getAuthUserId(session), "Add to chrome button", { type: "link", eventStatusFlag: 1, source: "navbar", name: getAuthUserName(session) }, anonymousId)
+		};
+		const downloadLink = document.getElementById('add-to-chrome-btn');
+		downloadLink?.addEventListener('click', handleDownloadClick);
+
+		return () => {
+			downloadLink?.removeEventListener('click', handleDownloadClick);
+		};
+	}, [rudderEventMethods, session, bannerHTML]);
 
 	return (<div className={`w-full ${bannerHeight} bg-primary-main flex justify-center align-middle text-primary-light`} >
 		{(bannerHeight) ? bannerHTML : null}

--- a/views/Navbar.tsx
+++ b/views/Navbar.tsx
@@ -75,6 +75,7 @@ const Navbar = (props: { ctaLink: string, transparent: boolean }) => {
 			docsLink?.removeEventListener('click', handleDocsClick);
 		};
 	}, [rudderEventMethods, session]);
+
 	return (
 		<AppBar position='fixed' offset={!props.transparent} className='mx-auto p-4 justify-between items-center max-w-7xl'
 			backdropClassName={'ease-in duration-300' + (scrollDown || !props.transparent ? ' bg-primary-light text-secondary-dark' : ' bg-transparent text-primary-light')}
@@ -124,16 +125,16 @@ const Navbar = (props: { ctaLink: string, transparent: boolean }) => {
 				}
 			>
 				<ul>
-					<li onClick={changeNavbar} className='p-4 text-4xl text-secondary-main hover:text-secondary-light'>
+					<li onClick={changeNavbar} id="docs-link" className='p-4 text-4xl text-secondary-main hover:text-secondary-light'>
 						<Link href='/docs'>Docs</Link>
 					</li>
-					<li onClick={changeNavbar} className='p-4 text-4xl text-secondary-main hover:text-secondary-light'>
+					<li onClick={changeNavbar} id="contribute-link" className='p-4 text-4xl text-secondary-main hover:text-secondary-light'>
 						<Link href='https://github.com/Alokit-Innovations' target='blank'>Contribute</Link>
 					</li>
-					<li onClick={changeNavbar} className='p-4 text-4xl text-secondary-main hover:text-secondary-light'>
-						<Link href='#'>Pricing</Link>
+					<li onClick={changeNavbar} id='pricing-link' className='p-4 text-4xl text-secondary-main hover:text-secondary-light'>
+						<Link href='/pricing'>Pricing</Link>
 					</li>
-					<li className='p-4 text-secondary-main hover:text-secondary-light'>
+					<li id='login-logout-link' className='p-4 text-secondary-main hover:text-secondary-light'>
 						<LoginLogout />
 					</li>
 				</ul>


### PR DESCRIPTION
Track event will be triggered in two cases:
1. On every page load that detects that our extension is not installed (or browser/device is incompatible with browser extensions)
2. When the "download" button is clicked in the banner to install the browser extension.

Other changes:
- Changed the copy for incompatible devices (asking them to use the website on a computer).
- Navbar bug fixes: the mobile menu didn't have the `id` attribute for eventing. And the "Pricing" link was dead for mobile.