### PR TITLE
banner warning fix

### DIFF
--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -7,27 +7,26 @@ const AppBar = (props: PropsWithChildren<{
 	className?: string,
 	backdropClassName?: string,
 }>) => {
+	const headerRef = useRef<HTMLDivElement>(null);
 	const appbarRef = useRef<HTMLDivElement>(null);
 	const offsetRef = useRef<HTMLDivElement>(null);
-	const [bannerHeight, setBannerHeight] = useState<BannerHeightType>();
 
 	useEffect(() => {
-		if (props.offset && appbarRef.current && offsetRef.current) {
-			offsetRef.current.style.height = `${appbarRef.current.clientHeight}px`;
+		if (headerRef.current && offsetRef.current) {
+			const offsetHeight = headerRef.current.clientHeight - ((!props.offset && appbarRef.current) ? appbarRef.current.clientHeight : 0);
+			offsetRef.current.style.height = `${offsetHeight}px`;
 		}
 	})
 
 	return (
 		<>
-			<header className={props.position + " w-full box-border z-20 top-0 right-0 left-auto shrink-0 print:absolute border-b-secondary-dark border-b-2 " + props.backdropClassName}>
-				<Banner bannerHeight={bannerHeight} setBannerHeight={setBannerHeight} />
+			<header ref={headerRef} className={props.position + " w-full box-border z-20 top-0 right-0 left-auto shrink-0 print:absolute border-b-secondary-dark border-b-2 " + props.backdropClassName}>
+				<Banner />
 				<div ref={appbarRef} className={"relative flex items-center px-2 " + props.className}>
 					{props.children}
 				</div>
 			</header>
-			<div className={`${bannerHeight}`}></div>
-			{(props.offset && (props.position === 'fixed') || ((props.position === 'absolute'))) &&
-				<div ref={offsetRef} className='relative'></div>}
+			<div ref={offsetRef} className='relative'></div>
 		</>
 	)
 }

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -6,11 +6,9 @@ import chromeLogo from '../public/chrome-logo.png'
 export type BannerHeightType = "h-12" | "h-24" | "h-32" | "h-40" | "h-44" | undefined;
 type BannerSituation = "not-installed" | "incompatible-browser" | "incompatible-device" | null;
 
-const Banner = ({ bannerHeight, setBannerHeight }: {
-	bannerHeight: BannerHeightType,
-	setBannerHeight: React.Dispatch<React.SetStateAction<BannerHeightType>>
-}) => {
+const Banner = () => {
 	const chromeExtensionLink = "https://chrome.google.com/webstore/detail/vibinex/jafgelpkkkopeaefadkdjcmnicgpcncc";
+	const [bannerHeight, setBannerHeight] = useState<BannerHeightType>();
 	const [bannerHTML, setBannerHTML] = useState((<></>));
 
 	useEffect(() => {
@@ -66,13 +64,13 @@ const Banner = ({ bannerHeight, setBannerHeight }: {
 		}
 
 		const determineSituation = (): BannerSituation => {
-            const isUnsupportedDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+			const isUnsupportedDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 			// currently, this is the best way to check if browser extensions are supported. Ref: https://stackoverflow.com/a/60927213/4677052
 			if ('chrome' in window && !isUnsupportedDevice) {
 				return null;
 			} else if (isUnsupportedDevice) {
-                return "incompatible-device";
-            } else {
+				return "incompatible-device";
+			} else {
 				return "incompatible-browser";
 			}
 		}


### PR DESCRIPTION
Fixed this warning that we were getting earlier:

> client.js:1 Warning: Cannot update a component (`Banner`) while rendering a different component (`AppBar`). To locate the bad setState() call inside `AppBar`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render

As a by-product, the `Banner` component is now self-sufficient and doesn't need any props!