### PR TITLE
Get user's repositories from Bitbucket API

### DIFF
--- a/utils/providerAPI/getUserRepositories.ts
+++ b/utils/providerAPI/getUserRepositories.ts
@@ -15,8 +15,49 @@ type GithubRepoObj = {
 	[property: string]: any
 }
 
-// type BitbucketRepoObj = {
-// }
+type BitbucketWorkspaceObj = {
+	type: string,
+	user: {
+		display_name: string,
+		links: object[],
+		type: 'user',
+		uuid: string,
+		account_id: string,
+		nickname: string
+	},
+	workspace: {
+		type: 'workspace',
+		uuid: string,
+		name: string,
+		slug: string,
+		links: object[]
+	},
+	links: { self: object[] },
+	added_on: string,
+	permission: string,
+	last_accessed: string
+}
+
+type BitbucketRepoObj = {
+	type: 'repository',
+	full_name: string,
+	links: object[],
+	name: string,
+	slug: string,
+	description: string,
+	scm: 'git',
+	owner: object,
+	workspace: {
+		type: 'workspace',
+		uuid: string,
+		name: string,
+		slug: string,
+		links: object[]
+	},
+	is_private: boolean,
+	project: object,
+	uuid: string,
+}
 
 // type GitlabRepoObj = {
 // }
@@ -36,7 +77,7 @@ const getUserRepositoriesForGitHub = async (access_key: string, authId?: string)
 			}
 		})
 			.catch(err => {
-				console.error(`[Profile] Error occurred while getting user repositories from GitHub API (provider-assigned id: ${authId}). Endpoint: ${endPoint}`, err.message);
+				console.error(`[getUserRepositories] Error occurred while getting user repositories from GitHub API (provider-assigned id: ${authId}). Endpoint: ${endPoint}`, err.message);
 				throw err;
 			})
 		const allGitHubRepoIdentifiers = repos.map(repo => ({
@@ -52,6 +93,42 @@ const getUserRepositoriesForGitHub = async (access_key: string, authId?: string)
 	return allGitHubRepositories;
 }
 
+export const getUserRepositoriesForBitbucket = async (access_key: string, authId?: string) => {
+	const workspacesEndPoint = '/user/permissions/workspaces';
+	const response: { data: { values: BitbucketWorkspaceObj[] }, status: number } = await axios.get(baseURL['bitbucket'] + workspacesEndPoint, {
+		headers: {
+			'Accept': 'application/json',
+			'Authorization': `Bearer ${access_key}`
+		}
+	}) // TODO: implement pagination
+	if (response.status !== 200) {
+		throw ReferenceError(`[getUserRepositories] Could not get Bitbucket workspaces of the user (auth-id: ${authId}`);
+	}
+
+	const workspaces = response.data.values.map((workspaceObj) => workspaceObj.workspace.slug);
+
+	const repositories: RepoIdentifier[] = []
+	for (const workspace of workspaces) {
+		const repositoriesEndPoint = `/repositories/${workspace}`;
+		const response: { data: { values: BitbucketRepoObj[] }, status: number } = await axios.get(baseURL['bitbucket'] + repositoriesEndPoint, {
+			headers: {
+				'Accept': 'application/json',
+				'Authorization': `Bearer ${access_key}`
+			}
+		}) // TODO: implement pagination
+		if (response.status !== 200) {
+			console.error(`[getUserRepositories] Could not get Bitbucket repositories for the workspace (${workspace}) for auth-id ${authId}`, response.data);
+		}
+		const allBitbucketRepoIdentifiers = response.data.values.map(repoObj => ({
+			repo_provider: supportedProviders[1],
+			repo_owner: repoObj.workspace.slug,
+			repo_name: repoObj.slug
+		}));
+		repositories.push(...allBitbucketRepoIdentifiers);
+	}
+	return repositories;
+}
+
 export const getUserRepositories = async (session: Session) => {
 	const allUserReposPromises = [];
 	for (const repoProvider of supportedProviders) {
@@ -62,6 +139,10 @@ export const getUserRepositories = async (session: Session) => {
 					case 'github':
 						const userReposPromiseGitHub = getUserRepositoriesForGitHub(access_key, authId)
 						allUserReposPromises.push(userReposPromiseGitHub);
+						break;
+					case 'bitbucket':
+						const userReposPromiseBitbucket = getUserRepositoriesForBitbucket(access_key, authId);
+						allUserReposPromises.push(userReposPromiseBitbucket);
 						break;
 					default:
 						break;

--- a/utils/providerAPI/getUserRepositories.ts
+++ b/utils/providerAPI/getUserRepositories.ts
@@ -118,6 +118,7 @@ export const getUserRepositoriesForBitbucket = async (access_key: string, authId
 		}) // TODO: implement pagination
 		if (response.status !== 200) {
 			console.error(`[getUserRepositories] Could not get Bitbucket repositories for the workspace (${workspace}) for auth-id ${authId}`, response.data);
+			continue;
 		}
 		const allBitbucketRepoIdentifiers = response.data.values.map(repoObj => ({
 			repo_provider: supportedProviders[1],


### PR DESCRIPTION
the `getUserRepositories` function was initially written to only work with GitHub. 
This PR adds support for Bitbucket.