### PR TITLE
Auth flow changes

### DIFF
--- a/components/LoginLogout.tsx
+++ b/components/LoginLogout.tsx
@@ -58,7 +58,7 @@ export default function LoginLogout() {
 					<li id='contribute-link' className='border-b-2 border-b-gray-200 p-2 text-center'>
 						<Link href='https://github.com/Alokit-Innovations/' target='_blank' className='cursor-pointer w-full'>Contribute</Link>
 					</li>
-					<li id='logout-link' className='p-2 text-center cursor-pointer' onClick={() => (logout(getAuthUserId(session), getAuthUserName(session), getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods ? rudderEventMethods : null)))}>
+					<li id='logout-link' className='p-2 text-center cursor-pointer' onClick={() => (logout(getAuthUserId(session), getAuthUserName(session), getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods || null)))}>
 						Logout
 					</li>
 				</ol>
@@ -68,7 +68,7 @@ export default function LoginLogout() {
 		</>
 	)
 	else return (
-		<Button variant='contained' onClick={() => (login(getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods ? rudderEventMethods : null)))} className="rounded bg-inherit sm:bg-primary-main text-secondary-main py-2 px-4 font-semibold">
+		<Button variant='contained' onClick={() => (login(getAndSetAnonymousIdFromLocalStorage(), (rudderEventMethods || null)))} className="rounded bg-inherit sm:bg-primary-main text-secondary-main py-2 px-4 font-semibold">
 			Login/Signup
 		</Button>
 	)

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -89,8 +89,8 @@ export const authOptions = {
 			else if (new URL(url).origin === baseUrl) path = new URL(url).pathname;
 			else path = "/";
 
-			if (path = "/") return `${baseUrl}/u`;
-			return baseUrl
+			if (path === "/") return `${baseUrl}/u`;
+			return `${baseUrl}${path}`
 		},
 		async session({ session }: { session: Session }) {
 			if (session && session.user) {

--- a/pages/api/events.ts
+++ b/pages/api/events.ts
@@ -2,8 +2,8 @@ import Analytics from "@rudderstack/rudder-sdk-node";
 import { apiObject } from "rudder-sdk-js";
 // we need the batch endpoint of the Rudder server you are running
 const client = (process.env.NODE_ENV === 'development') ? {
-	identify: (event_properties: object) => console.info(event_properties),
-	track: (event_properties: object) => console.info(event_properties)
+	identify: (event_properties: object) => console.info("[mock-rs] identify", event_properties),
+	track: (event_properties: object) => console.info("[mock-rs] track", event_properties)
 } : new Analytics(process.env.RUDDERSTACK_SERVER_WRITE_KEY!, { dataPlaneUrl: process.env.RUDDERSTACK_SERVER_DATA_PLANE_URL });
 
 const rudderStackEvents = {

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -52,7 +52,7 @@ const Docs = ({ bitbucket_auth_url }: { bitbucket_auth_url: string }) => {
 					subHeading: "Sign up with github",
 					article: <span className="text-blue-500 cursor-pointer" onClick={() => login(
 						getAndSetAnonymousIdFromLocalStorage(),
-						(rudderEventMethods ? rudderEventMethods : null),
+						(rudderEventMethods || null),
 						'github'
 					)}>Sign in on Vibinex using GitHub</span>
 				},
@@ -91,7 +91,7 @@ jobs:
 				{
 					subHeading: "Sign up with Bitbucket", article: <span className="text-blue-500 cursor-pointer" onClick={() => login(
 						getAndSetAnonymousIdFromLocalStorage(),
-						(rudderEventMethods ? rudderEventMethods : null),
+						(rudderEventMethods || null),
 						'bitbucket'
 					)}>Sign in on Vibinex using Bitbucket</span>
 				},

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -7,7 +7,7 @@ import MainAppBar from '../../views/MainAppBar';
 import Footer from '../../components/Footer';
 import RudderContext from '../../components/RudderContext';
 import { getAndSetAnonymousIdFromLocalStorage } from '../../utils/rudderstack_initialize';
-import { getAuthUserId, getAuthUserName } from '../../utils/auth';
+import { getAuthUserId, getAuthUserName, login } from '../../utils/auth';
 
 const verifySetup = [
 	"In your organization's repository list, you will see the Vibinex logo in front of the repositories that are correctly set up with Vibinex.",
@@ -48,7 +48,14 @@ const Docs = ({ bitbucket_auth_url }: { bitbucket_auth_url: string }) => {
 			heading: "Github",
 			flag: true,
 			content: [
-				{ subHeading: "Sign up with github", article: "Sign in on Vibinex using GitHub" },
+				{
+					subHeading: "Sign up with github",
+					article: <span className="text-blue-500 cursor-pointer" onClick={() => login(
+						getAndSetAnonymousIdFromLocalStorage(),
+						(rudderEventMethods ? rudderEventMethods : null),
+						'github'
+					)}>Sign in on Vibinex using GitHub</span>
+				},
 				{ subHeading: "Install GitHub App", article: <>Install <Link id="github-app-install" href="https://github.com/apps/vibinex-code-review" target='_blank' className="text-blue-500">Repo Profiler Github App</Link> from Github Marketplace in your org/personal account. Make sure you have the permissions required to install the app.</> },
 				{
 					subHeading: "Setup GitHub Action",
@@ -81,7 +88,13 @@ jobs:
 			heading: "Bitbucket",
 			flag: false,
 			content: [
-				{ subHeading: "Sign up with Bitbucket", article: "Sign in on Vibinex using Bitbucket" },
+				{
+					subHeading: "Sign up with Bitbucket", article: <span className="text-blue-500 cursor-pointer" onClick={() => login(
+						getAndSetAnonymousIdFromLocalStorage(),
+						(rudderEventMethods ? rudderEventMethods : null),
+						'bitbucket'
+					)}>Sign in on Vibinex using Bitbucket</span>
+				},
 				{
 					subHeading: "Install OAuth consumer", article: <>
 						<Button

--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -29,7 +29,7 @@ const pricingPlan = [
 		pricing: undefined, // will be populated by formula
 		features: ['Access of all features', 'Direct support through Slack', 'Free-of-cost setup assistance'],
 		buttonText: 'Start your 30 day trial',
-		link: '/api/auth/signin?callbackUrl=https%3A%2F%2Fvibinex.com%2Fpricing%2F' // temp. adding login page link, need to replace it with payment link
+		link: '/u'
 	},
 	{
 		pricingName: 'Enterprise',
@@ -63,7 +63,7 @@ const Pricing = () => {
 		return (<span className='font-money'>  {currency} <span className='text-4xl'>{price} </span ></span>);
 	}
 
-	const pricingStartDate = new Date(2023, 7, 31); // 31st August 2023
+	const pricingStartDate = new Date(2023, 9, 31); // 31st October 2023
 	const today = new Date();
 	const readableDate = (date: Date) => date.toLocaleDateString('en-us', { year: 'numeric', month: 'long', day: 'numeric' })
 

--- a/pages/u.tsx
+++ b/pages/u.tsx
@@ -13,6 +13,7 @@ import { getAndSetAnonymousIdFromLocalStorage } from "../utils/rudderstack_initi
 import MainAppBar from "../views/MainAppBar";
 import RepoList, { getRepoList } from "../views/RepoList";
 import { authOptions } from "./api/auth/[...nextauth]";
+import { getURLWithParams } from "../utils/url_utils";
 
 type ProfileProps = {
 	session: Session,
@@ -60,7 +61,9 @@ export const getServerSideProps: GetServerSideProps<ProfileProps> = async ({ req
 	if (!session) {
 		return {
 			redirect: {
-				destination: '/api/auth/signin',
+				destination: getURLWithParams('/api/auth/signin', {
+					callbackUrl: `${process.env.NEXTAUTH_URL}/u`
+				}),
 				permanent: false
 			}
 		};

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,5 +1,6 @@
 import NextAuth, { DefaultSession } from "next-auth";
 import AuthInfo from "./AuthInfo";
+import { BuiltInProviderType } from "next-auth/providers";
 
 declare module "next-auth" {
 	interface Session extends DefaultSession {
@@ -11,4 +12,6 @@ declare module "next-auth" {
 			auth_info?: AuthInfo
 		}
 	}
+
+	type AuthProviderType = BuiltInProviderType | 'bitbucket'
 }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,9 +1,10 @@
 import { signIn, signOut } from 'next-auth/react';
 import type { Session } from 'next-auth/core/types';
 import { RudderstackClientSideEvents } from './rudderstack_initialize';
+import { AuthProviderType } from 'next-auth';
 
-export const login = (anonymousId: string, rudderEventMethods: RudderstackClientSideEvents | null) => {
-	signIn().catch((err) => {
+export const login = (anonymousId: string, rudderEventMethods: RudderstackClientSideEvents | null, provider?: AuthProviderType) => {
+	signIn(provider).catch((err) => {
 		rudderEventMethods?.track(``, "login", { eventStatusFlag: 0, source: "profile-popup" }, anonymousId)
 		console.error("[signIn] Authentication failed.", err);
 	})


### PR DESCRIPTION
1. Logging in from any general page will keep you on the same page except the landing page - which sends you to u.tsx. Earlier, login would always send you to u.tsx
2. Pricing page: sends to u.tsx, now that login is currently handled in it. Also changed the applicability date to 31 Oct 2023
3. The login function in auth.ts now takes an option provider parameter that can directly let the user log in using a provider.
  i. Used this function in the docs to convert the first step into a link. Now the docs page can directly be shared.
