### PR TITLE
added pagination in the db query for getting user repositories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibinex-website",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibinex-website",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@google-cloud/pubsub": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibinex-website",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "homepage": "https://vibinex.com",
   "description": "A plugin that works with GitHub, Bitbucket and GitLab to personalize and data-enrich their code review interfaces",

--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -3,16 +3,24 @@ import type { DbRepo, RepoIdentifier } from '../../types/repository';
 import { convert } from './converter';
 
 export const getRepos = async (allRepos: RepoIdentifier[]) => {
-	const allReposFormattedAsTuples = allRepos.map(repo => `(${convert(repo.repo_provider)}, ${convert(repo.repo_owner)}, ${convert(repo.repo_name)})`).join(',');
-	const repo_list_q = `SELECT *
+	const batchSize = 50;
+	const allDbRepos = [];
+	for (let index = 0; index < allRepos.length; index += batchSize) {
+		const allReposSubset = allRepos.slice(index, index + batchSize);
+		const allReposFormattedAsTuples = allReposSubset.map(repo => `(${convert(repo.repo_provider)}, ${convert(repo.repo_owner)}, ${convert(repo.repo_name)})`).join(',');
+		console.log('[getRepos] allReposFormatedAsTuples:', allReposSubset.length, allReposFormattedAsTuples.length, allReposFormattedAsTuples);
+		const repo_list_q = `SELECT *
 		FROM repos 
 		WHERE (repo_provider, repo_owner, repo_name) IN (${allReposFormattedAsTuples})
 		ORDER BY repo_provider, repo_owner, repo_name`;
-	const result: { rows: DbRepo[] } = await conn.query(repo_list_q).catch(err => {
-		console.error(`[getRepos] Error in getting repository-list from the database`, { pg_query: repo_list_q }, err);
-		throw new Error(err); // FIXME: handle this more elegantly
-	});
-	return result.rows
+		const result: { rows: DbRepo[] } = await conn.query(repo_list_q).catch(err => {
+			console.error(`[getRepos] Error in getting repository-list from the database`, { pg_query: repo_list_q }, err);
+			throw new Error(err); // FIXME: handle this more elegantly
+		});
+		allDbRepos.push(...result.rows);
+	}
+
+	return allDbRepos;
 }
 
 export const setRepoConfig = async (repo: RepoIdentifier, configType: 'auto_assign' | 'comment', value: boolean) => {

--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -9,9 +9,9 @@ export const getRepos = async (allRepos: RepoIdentifier[]) => {
 		const allReposSubset = allRepos.slice(index, index + batchSize);
 		const allReposFormattedAsTuples = allReposSubset.map(repo => `(${convert(repo.repo_provider)}, ${convert(repo.repo_owner)}, ${convert(repo.repo_name)})`).join(',');
 		const repo_list_q = `SELECT *
-		FROM repos 
-		WHERE (repo_provider, repo_owner, repo_name) IN (${allReposFormattedAsTuples})
-		ORDER BY repo_provider, repo_owner, repo_name`;
+			FROM repos 
+			WHERE (repo_provider, repo_owner, repo_name) IN (${allReposFormattedAsTuples})
+			ORDER BY repo_provider, repo_owner, repo_name`;
 		const DbRepoSubsetPromise: Promise<{ rows: DbRepo[] }> = conn.query(repo_list_q).catch(err => {
 			console.error(`[getRepos] Error in getting repository-list from the database`, { pg_query: repo_list_q }, err);
 			throw new Error(`Error in getting repository-list from the database. Batch: ${index}:${index + batchSize - 1}. Error: ${err.message}`);
@@ -20,13 +20,19 @@ export const getRepos = async (allRepos: RepoIdentifier[]) => {
 	}
 
 	const allDbRepos = await Promise.allSettled(allDbReposPromises).then(results => {
+		let numFailedPromises = 0;
 		const allDbRepoLists = results.map((result) => {
 			if (result.status !== 'fulfilled') {
+				console.error(`[getRepos]`, result.reason);
+				numFailedPromises++;
 				return [];
 			}
 			return result.value.rows;
 		})
-		return allDbRepoLists.flat();
+		return {
+			repos: allDbRepoLists.flat(),
+			failureRate: numFailedPromises / allDbReposPromises.length
+		};
 	})
 
 	return allDbRepos;

--- a/utils/providerAPI/getEmailAliases.ts
+++ b/utils/providerAPI/getEmailAliases.ts
@@ -56,6 +56,7 @@ export const getEmailAliases = async (session: Session) => {
 	await Promise.allSettled(allUserEmailsPromises).then((results) => {
 		results.forEach((result) => {
 			if (result.status !== 'fulfilled') {
+				console.error(`[getEmailAliases] Promise rejected for one of the providers with this reason: ${result.reason}`);
 				return;
 			}
 			const emailObjects = result.value;

--- a/utils/providerAPI/getEmailAliases.ts
+++ b/utils/providerAPI/getEmailAliases.ts
@@ -53,7 +53,7 @@ export const getEmailAliases = async (session: Session) => {
 	}
 
 	const allAliases: Set<string> = new Set();
-	Promise.allSettled(allUserEmailsPromises).then((results) => {
+	await Promise.allSettled(allUserEmailsPromises).then((results) => {
 		results.forEach((result) => {
 			if (result.status !== 'fulfilled') {
 				return;


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `getRepos` function in `utils/db/repos.ts` to retrieve repositories from the database in batches, improving performance and handling of large datasets.
- Refactor: Updated the `getEmailAliases` function in `utils/providerAPI/getEmailAliases.ts` to use `await` with `Promise.allSettled`, ensuring all promises settle before proceeding.
- Bug Fix: Improved error handling in `views/RepoList.tsx` for fetching user repositories. Now returns an empty array on failure, preventing potential crashes.
- Refactor: The `created_at` property of each repository in `views/RepoList.tsx` is now converted to a formatted date string, enhancing readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->