### PR TITLE
Leftover changes from tr/onprem that are not in main

### DIFF
--- a/pages/api/bitbucket/callbacks/webhook.ts
+++ b/pages/api/bitbucket/callbacks/webhook.ts
@@ -1,7 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { publishMessage } from '../../../../utils/pubsub/pubsubClient';
 import { getTopicNameFromDB } from '../../../../utils/db/relevance';
-import { getRepoConfig } from '../../../..//utils/db/repos'; // Make sure to import the getRepoConfig function
 
 const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const jsonBody = req.body;
@@ -9,18 +8,10 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const provider = "bitbucket";
   const name = jsonBody.repository.name;
   const topicName = await getTopicNameFromDB(owner, name, provider);
-
-  // Fetch the repository configuration
-  const repoConfig = await getRepoConfig({
-    repo_provider: provider,
-    repo_owner: owner,
-    repo_name: name
-  });
-
+  
   const data = {
     repositoryProvider: 'bitbucket',
-    eventPayload: jsonBody,
-    repoConfig: repoConfig // Add the fetched configuration to the data object
+    eventPayload: jsonBody
   };
   
   const msgType = 'webhook_callback';
@@ -28,7 +19,6 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.info("Received bitbucket webhook event for ", name);
   console.debug(`data = ${JSON.stringify(jsonBody)}`)
   console.debug(`topicname = ${topicName}`)
-  console.debug(`repoConfig = ${JSON.stringify(repoConfig)}`)
   
   try {
     await publishMessage(topicName, data, msgType);

--- a/pages/api/bitbucket/callbacks/webhook.ts
+++ b/pages/api/bitbucket/callbacks/webhook.ts
@@ -17,16 +17,17 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const msgType = 'webhook_callback';
   
   console.info("Received bitbucket webhook event for ", name);
+  console.debug(`data = ${JSON.stringify(jsonBody)}`)
+  console.debug(`topicname = ${topicName}`)
   
   try {
     await publishMessage(topicName, data, msgType);
+    res.status(200);
+    res.send("Success");
   } catch (error) {
     console.error('Error publishing message:', error);
     res.status(500).json({ error: 'Failed to publish message. Data must be in the form of a Buffer' });
   }
-  
-  res.status(200);
-  res.send("Success");
 }
 
 export default webhookHandler;

--- a/pages/api/bitbucket/callbacks/webhook.ts
+++ b/pages/api/bitbucket/callbacks/webhook.ts
@@ -19,15 +19,13 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.info("Received bitbucket webhook event for ", name);
   console.debug(`data = ${JSON.stringify(jsonBody)}`)
   console.debug(`topicname = ${topicName}`)
-  
-  try {
-    await publishMessage(topicName, data, msgType);
-    res.status(200);
-    res.send("Success");
-  } catch (error) {
+
+  await publishMessage(topicName, data, msgType).catch((error) => {
     console.error('Error publishing message:', error);
-    res.status(500).json({ error: 'Failed to publish message. Data must be in the form of a Buffer' });
-  }
+    res.status(500).json({ error: 'Failed to publish Pubsub message.' });
+  });
+  res.status(200);
+  res.send("Success");
 }
 
 export default webhookHandler;

--- a/pages/api/bitbucket/callbacks/webhook.ts
+++ b/pages/api/bitbucket/callbacks/webhook.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { publishMessage } from '../../../../utils/pubsub/pubsubClient';
 import { getTopicNameFromDB } from '../../../../utils/db/relevance';
+import { getRepoConfig } from '../../../..//utils/db/repos'; // Make sure to import the getRepoConfig function
 
 const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const jsonBody = req.body;
@@ -8,10 +9,18 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const provider = "bitbucket";
   const name = jsonBody.repository.name;
   const topicName = await getTopicNameFromDB(owner, name, provider);
-  
+
+  // Fetch the repository configuration
+  const repoConfig = await getRepoConfig({
+    repo_provider: provider,
+    repo_owner: owner,
+    repo_name: name
+  });
+
   const data = {
     repositoryProvider: 'bitbucket',
-    eventPayload: jsonBody
+    eventPayload: jsonBody,
+    repoConfig: repoConfig // Add the fetched configuration to the data object
   };
   
   const msgType = 'webhook_callback';
@@ -19,6 +28,7 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.info("Received bitbucket webhook event for ", name);
   console.debug(`data = ${JSON.stringify(jsonBody)}`)
   console.debug(`topicname = ${topicName}`)
+  console.debug(`repoConfig = ${JSON.stringify(repoConfig)}`)
   
   try {
     await publishMessage(topicName, data, msgType);

--- a/pages/api/rustApp/setup.ts
+++ b/pages/api/rustApp/setup.ts
@@ -4,8 +4,7 @@ import { saveTopicName } from '../../../utils/db/relevance';
 const setupHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.info("Saving setup info in db...");
     const jsonBody = req.body;
-    for (const idx in jsonBody.info) {
-        let ownerInfo = jsonBody.info[idx];
+    for (const ownerInfo of jsonBody.info) {
         try {
             await saveTopicName(ownerInfo.owner, ownerInfo.provider, 
                 jsonBody.installationId, ownerInfo.repos);

--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -57,3 +57,26 @@ export const setRepoConfig = async (repo: RepoIdentifier, configType: 'auto_assi
 		})
 	return queryIsSuccessful;
 };
+
+export const getRepoConfig = async (repo: RepoIdentifier) => {
+    const get_repo_config_q = `
+        SELECT config 
+        FROM repos 
+        WHERE repo_provider = ${convert(repo.repo_provider)}
+            AND repo_owner = ${convert(repo.repo_owner)}
+            AND repo_name = ${convert(repo.repo_name)}`;
+
+    const config = await conn.query(get_repo_config_q)
+        .then((dbResponse) => {
+            if (dbResponse.rowCount == 0) {
+                throw new Error(`Repository not found: ${JSON.stringify(repo)}`);
+            }
+            return dbResponse.rows[0].config;
+        })
+        .catch((err: Error) => {
+            console.error(`[db/getRepoConfig] Could not retrieve config of this repository: ${repo}`, { pg_query: get_repo_config_q }, err);
+            throw err;
+        });
+
+    return config;
+};

--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -57,26 +57,3 @@ export const setRepoConfig = async (repo: RepoIdentifier, configType: 'auto_assi
 		})
 	return queryIsSuccessful;
 };
-
-export const getRepoConfig = async (repo: RepoIdentifier) => {
-    const get_repo_config_q = `
-        SELECT config 
-        FROM repos 
-        WHERE repo_provider = ${convert(repo.repo_provider)}
-            AND repo_owner = ${convert(repo.repo_owner)}
-            AND repo_name = ${convert(repo.repo_name)}`;
-
-    const config = await conn.query(get_repo_config_q)
-        .then((dbResponse) => {
-            if (dbResponse.rowCount == 0) {
-                throw new Error(`Repository not found: ${JSON.stringify(repo)}`);
-            }
-            return dbResponse.rows[0].config;
-        })
-        .catch((err: Error) => {
-            console.error(`[db/getRepoConfig] Could not retrieve config of this repository: ${repo}`, { pg_query: get_repo_config_q }, err);
-            throw err;
-        });
-
-    return config;
-};


### PR DESCRIPTION
Should have been merged in PR #115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added a new function `getRepoConfig` in `utils/db/repos.ts` to fetch repository configuration from the database. This will help in better handling of repository-specific configurations.

**Improvements:**
- Enhanced error handling and logging in `pages/api/bitbucket/callbacks/webhook.ts`. Now, it provides more informative debug logs and handles errors during message publishing more gracefully.
- Improved code readability in `pages/api/rustApp/setup.ts` by replacing `for...in` loop with `for...of` loop for iterating over `jsonBody.info`.

**Bug Fixes:**
- Fixed an issue where the server response was not properly set after successful message publishing in `pages/api/bitbucket/callbacks/webhook.ts`. Now, it correctly sends a 200 status with "Success" as the response body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->