### PR TITLE
Added error logs in getUserRepositories from provider

### DIFF
--- a/utils/providerAPI/getUserRepositories.ts
+++ b/utils/providerAPI/getUserRepositories.ts
@@ -81,6 +81,9 @@ const getUserRepositoriesForGitHub = async (access_key: string, authId?: string)
 				console.error(`[getUserRepositories] Error occurred while getting user repositories from GitHub API (provider-assigned id: ${authId}). Endpoint: ${endPoint}`, err.message);
 				throw err;
 			})
+		if (repos.length === 0) {
+			console.warn(`[getUserRepositories] No repositories received from GitHub API (provider-assigned id: ${authId}). Endpoint: ${endPoint}`);
+		}
 		const allGitHubRepoIdentifiers = repos.map(repo => ({
 			repo_provider: supportedProviders[0],
 			repo_owner: repo.full_name.split('/')[0],
@@ -139,6 +142,7 @@ export const getUserRepositories = async (session: Session) => {
 	await Promise.allSettled(allUserReposPromises).then((results) => {
 		results.forEach((result) => {
 			if (result.status !== 'fulfilled') {
+				console.error(`[getUserRepositories] Failed to get repositories of the user (id: ${session.user.id}, name: ${session.user.name}) from one of the providers`, result.reason);
 				return;
 			}
 			const providerRepos = result.value;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced error handling in `getUserRepositories.ts` utility. Now, if no repositories are received from the GitHub API, a console warning will be generated for better debugging.
- Bug Fix: Improved logging for failures when attempting to get user repositories from providers. This will aid in identifying and resolving issues more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->