### PR TITLE
Made `db/user/createUpdateUserObj` function more modular and readable.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
+  setupFiles: ['./test/text-encoder-polyfill.ts'], // Add this line to include the polyfill
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/test/text-encoder-polyfill.ts
+++ b/test/text-encoder-polyfill.ts
@@ -2,3 +2,5 @@
 if (typeof TextEncoder === 'undefined') {
 	global.TextEncoder = require('util').TextEncoder;
 }
+
+export { }

--- a/test/text-encoder-polyfill.ts
+++ b/test/text-encoder-polyfill.ts
@@ -1,0 +1,4 @@
+// text-encoder-polyfill.js
+if (typeof TextEncoder === 'undefined') {
+	global.TextEncoder = require('util').TextEncoder;
+}

--- a/utils/db/users.test.ts
+++ b/utils/db/users.test.ts
@@ -114,6 +114,50 @@ describe('unit testing auth-info updates in updateUser object creation', () => {
 			expect(Object.keys(actual_output).length).toBe(1);
 	})
 
+	it("repeating auth with updated handle details (and older expiry)", async () => {
+		const original_auth_info = await getOriginalAuthInfo(TEST_USERID);
+		const new_user: DbUser = {
+			auth_info: JSON.parse(JSON.stringify(original_auth_info))
+		};
+		const bitbucketProviderId = "712020:fd994dba-f921-420b-a9af-8b150ee17d5a";
+		expect(new_user?.auth_info?.bitbucket).toHaveProperty(bitbucketProviderId)
+		if (new_user?.auth_info?.bitbucket[bitbucketProviderId] === undefined) {
+			console.error("Outdated test data, auth_info does not contain expected bitbucket key");
+			return;
+		}
+		new_user.auth_info.bitbucket[bitbucketProviderId].handle = "newhandle";
+		new_user.auth_info.bitbucket[bitbucketProviderId].expires_at = 1695543210; // older timestamp than original
+		const actual_output = await createUpdateUserObj(TEST_USERID, new_user);
+
+		expect(actual_output?.auth_info).toStrictEqual(new_user.auth_info);
+		expect(actual_output?.auth_info).not.toStrictEqual(original_auth_info);
+		if (actual_output)
+			expect(Object.keys(actual_output).length).toBe(1);
+	})
+
+	it("repeating auth with handle that didn't previously exist details (and older expiry)", async () => {
+		const original_auth_info = await getOriginalAuthInfo(TEST_USERID);
+		const new_user: DbUser = {
+			auth_info: JSON.parse(JSON.stringify(original_auth_info))
+		};
+
+		const bitbucketProviderId = "712020:fd994dba-f921-420b-a9af-8b150ee17d5a";
+		delete original_auth_info.bitbucket[bitbucketProviderId].handle;
+		expect(new_user?.auth_info?.bitbucket).toHaveProperty(bitbucketProviderId)
+		if (new_user?.auth_info?.bitbucket[bitbucketProviderId] === undefined) {
+			console.error("Outdated test data, auth_info does not contain expected bitbucket key");
+			return;
+		}
+		new_user.auth_info.bitbucket[bitbucketProviderId].handle = "newhandle";
+		new_user.auth_info.bitbucket[bitbucketProviderId].expires_at = 1695543210; // older timestamp than original
+		const actual_output = await createUpdateUserObj(TEST_USERID, new_user);
+
+		expect(actual_output?.auth_info).toStrictEqual(new_user.auth_info);
+		expect(actual_output?.auth_info).not.toStrictEqual(original_auth_info);
+		if (actual_output)
+			expect(Object.keys(actual_output).length).toBe(1);
+	})
+
 	it("repeating auth with updated details", async () => {
 		const original_auth_info = await getOriginalAuthInfo(TEST_USERID);
 		const new_user: DbUser = {

--- a/utils/db/users.test.ts
+++ b/utils/db/users.test.ts
@@ -2,8 +2,8 @@ import conn from ".";
 import AuthInfo from "../../types/AuthInfo";
 import { DbUser, createUpdateUserObj } from "./users";
 
-const TEST_USERID = 'f0aab7ff-f241-4eb4-9d3f-672fa2f6d979'
-const RANDOM_UID = '2893hdf9qss-jdhf9q3f982q34hrh0-2dfhq'
+const TEST_USERID = '3e5738b2-9b08-49b9-9eb8-9fbf32c1d725';
+const RANDOM_UID = '2893hdf9qss-jdhf9q3f982q34hrh0-2dfhq';
 
 describe('unit testing updateUser object creation (except auth_info)', () => {
 	it("changing id", async () => {
@@ -55,7 +55,7 @@ describe('unit testing updateUser object creation (except auth_info)', () => {
 	})
 
 	it("repeating same aliases", async () => {
-		const new_user: DbUser = { aliases: ["contact@vibinex.com", "test@vibinex.com", "129674662+Vibinextest@users.noreply.github.com"] };
+		const new_user: DbUser = { aliases: ["vibi-test@vibinex.com"] };
 		const actual_output = await createUpdateUserObj(TEST_USERID, new_user).catch(err => {
 			console.error("[Test] function call failed.", err)
 		});
@@ -71,19 +71,19 @@ describe('unit testing updateUser object creation (except auth_info)', () => {
 			console.error("[Test] function call failed.", err)
 		});
 
-		expect(actual_output?.aliases?.length).toBe(5);
+		expect(actual_output?.aliases?.length).toBe(3);
 		if (actual_output)
 			expect(Object.keys(actual_output).length).toBe(1);
 		new_user.aliases?.forEach(alias => expect(actual_output?.aliases).toContain(alias));
 	})
 
 	it("adding and repeating aliases", async () => {
-		const new_user: DbUser = { aliases: ["contact@vibinex.com", "newemail@example.com"] };
+		const new_user: DbUser = { aliases: ["vibi-test@vibinex.com", "newemail@example.com"] };
 		const actual_output = await createUpdateUserObj(TEST_USERID, new_user).catch(err => {
 			console.error("[Test] function call failed.", err)
 		});
 
-		expect(actual_output?.aliases?.length).toBe(4);
+		expect(actual_output?.aliases?.length).toBe(2);
 		if (actual_output)
 			expect(Object.keys(actual_output).length).toBe(1);
 		new_user.aliases?.forEach(alias => expect(actual_output?.aliases).toContain(alias));
@@ -118,11 +118,12 @@ describe('unit testing auth-info updates in updateUser object creation', () => {
 		const original_auth_info = await getOriginalAuthInfo(TEST_USERID);
 		const new_user: DbUser = {
 			auth_info: {
-				"github": {
-					"129674662": {
+				"bitbucket": {
+					"712020:fd994dba-f921-420b-a9af-8b150ee17d5a": {
 						"type": "oauth",
-						"scope": "read:user,user:email",
-						"access_token": "gho_AKL890fj3jkaLJF09j34flkjlKJF0uLkjgf9"
+						"access_token": "aRandomStringThatIamGeneratingJustforThis1test",
+						"expires_at": 1695554248,
+						"handle": "vibitest"
 					}
 				}
 			}
@@ -139,7 +140,7 @@ describe('unit testing auth-info updates in updateUser object creation', () => {
 		const original_auth_info = await getOriginalAuthInfo(TEST_USERID);
 		const new_user: DbUser = {
 			auth_info: {
-				"github": {
+				"bitbucket": {
 					"129674663": {
 						"type": "oauth",
 						"scope": "read:user,user:email",
@@ -153,10 +154,10 @@ describe('unit testing auth-info updates in updateUser object creation', () => {
 		if (actual_output)
 			expect(Object.keys(actual_output).length).toBe(1);
 		expect(actual_output?.auth_info).not.toStrictEqual(original_auth_info);
-		expect(actual_output?.auth_info?.github).toHaveProperty('129674662');
-		expect(actual_output?.auth_info?.github['129674662']).toStrictEqual(original_auth_info.github['129674662']);
-		expect(actual_output?.auth_info?.github).toHaveProperty('129674663');
-		expect(actual_output?.auth_info?.github['129674663']).toStrictEqual(new_user.auth_info?.github['129674663']);
+		expect(actual_output?.auth_info?.bitbucket).toHaveProperty('712020:fd994dba-f921-420b-a9af-8b150ee17d5a');
+		expect(actual_output?.auth_info?.bitbucket['712020:fd994dba-f921-420b-a9af-8b150ee17d5a']).toStrictEqual(original_auth_info.bitbucket['712020:fd994dba-f921-420b-a9af-8b150ee17d5a']);
+		expect(actual_output?.auth_info?.bitbucket).toHaveProperty('129674663');
+		expect(actual_output?.auth_info?.bitbucket['129674663']).toStrictEqual(new_user.auth_info?.bitbucket['129674663']);
 	})
 
 	it("adding new auth provider", async () => {
@@ -180,7 +181,7 @@ describe('unit testing auth-info updates in updateUser object creation', () => {
 		expect(actual_output?.auth_info).not.toStrictEqual(original_auth_info);
 		expect(actual_output?.auth_info).toHaveProperty('google');
 		expect(actual_output?.auth_info?.google).toStrictEqual(new_user.auth_info?.google);
-		expect(actual_output?.auth_info).toHaveProperty('github');
-		expect(actual_output?.auth_info?.github).toStrictEqual(original_auth_info.github);
+		expect(actual_output?.auth_info).toHaveProperty('bitbucket');
+		expect(actual_output?.auth_info?.bitbucket).toStrictEqual(original_auth_info.bitbucket);
 	})
 })

--- a/utils/db/users.ts
+++ b/utils/db/users.ts
@@ -135,7 +135,7 @@ const calculateAuthDiff = (currAuthInfo: AuthInfo, newAuthInfo?: AuthInfo) => {
 			if (!(newAuthObj.expires_at && currAuthObj.expires_at && newAuthObj.expires_at < currAuthObj.expires_at)) {
 				diffAuth[provider][providerAccountId] = newAuthObj;
 			}
-			if ((newAuthObj.handle && !currAuthObj.handle) || (newAuthObj.handle != currAuthObj.handle)) {
+			if (newAuthObj.handle != currAuthObj?.handle) {
 				diffAuth[provider][providerAccountId] = newAuthObj;
 			}
 		}


### PR DESCRIPTION
- Modularized the operation for calculating the diff sub-object for auth-info to reduce cognitive load.
- Discovered that the tests were no longer working - figured out that it was because of the `pg` library's version update. And fixed it by creating the Polyfill for TextEncoder.
- Updated the tests according to the data in the `test-db`. Original tests contained expected values based on data in the prod database.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a function `calculateAuthDiff` in `utils/db/users.ts` to calculate the difference between two authentication objects, enhancing the user update process.
- Test: Updated test cases in `utils/db/users.test.ts` for creating and updating user objects, improving coverage for scenarios related to user information and authentication details updates.
- Chore: Added a polyfill for `TextEncoder` in `test/text-encoder-polyfill.ts`, ensuring compatibility across different environments.
- Refactor: Extracted logic for calculating `auth_info` differences into a separate function in `utils/db/users.ts`, improving code modularity and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->