### PR TITLE
fixed github app access_token error, instead of query code we must use `installation_id` from the req.query to get the access_token

### DIFF
--- a/pages/api/github/callbacks/install.ts
+++ b/pages/api/github/callbacks/install.ts
@@ -15,7 +15,7 @@ const installHandler = async (req: NextApiRequest, res: NextApiResponse) => {
 	}
 	const data = {
 		'repository_provider': 'github',
-		'installation_code': req.query.code
+		'installation_code': req.query.installation_id,
 	};
 	const msgType = 'install_callback';
 	console.info("Recieved installation code for github, published to ", topicName);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the authentication process in our API. We've switched from using an installation code to an installation ID for improved security and reliability. This change is behind-the-scenes and won't affect your user experience, but it helps us ensure a more secure and stable platform for you.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->