### PR TITLE
fix: hide quote author attribution when author field is null

### DIFF
--- a/components/blog/Quote.tsx
+++ b/components/blog/Quote.tsx
@@ -35,7 +35,7 @@ const Quote = ({ data }: QuoteProps) => {
 				</svg>
 			</div>
 			<span className="w-12 h-1 my-2 rounded-lg dark:bg-violet-400"></span>
-			{author ? <p>{author}</p> : "unknown"}
+			{author && <p>{author}</p>}
 		</div>
 	);
 }


### PR DESCRIPTION
## Problem
The Quote component renders the string `"unknown"` when the Strapi `author` field is null, which looks bad on the live article page.

## Fix
Changed `{author ? <p>{author}</p> : "unknown"}` to `{author && <p>{author}</p>}` — when `author` is null, nothing is rendered.

## Testing
- Article at `/blog/engineering/code-review-broken-ai` has a quote block with no author set
- Before: shows "unknown" under the quote
- After: quote displays cleanly with no attribution line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated blog quote component to hide the author section when author information is unavailable, instead of displaying "unknown".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->