### PR TITLE
fix: increase DB connection timeout from 2s to 10s and add SSL for Supabase pooler

### DIFF
--- a/utils/db/index.ts
+++ b/utils/db/index.ts
@@ -6,9 +6,10 @@ const conn = new Pool({
 	host: process.env.PGSQL_HOST,
 	port: parseInt(process.env.PGSQL_PORT ?? "0"),
 	database: process.env.PGSQL_DATABASE,
+	ssl: process.env.PGSQL_HOST?.includes('supabase') ? { rejectUnauthorized: false } : undefined,
 	max: 20,
 	idleTimeoutMillis: 30000,
-	connectionTimeoutMillis: 2000,
+	connectionTimeoutMillis: 10000,
 })
 
 export default conn;


### PR DESCRIPTION
## Problem
The `PGSQL_*` env vars now point to Supabase's transaction pooler (`aws-0-ap-south-1.pooler.supabase.com:6543`). Cold connections from Vercel's US-based serverless functions to this AWS India endpoint can take 3–5 seconds, consistently exceeding the hardcoded `connectionTimeoutMillis: 2000`.

This caused:
- `getUserByAlias()` in the `session` callback to silently fail (timeout)
- `session.user.id` never gets set
- `/u` page shows `{"error": "No user id in session"}`

The new OAuth login also showed `error=OAuthCallback` — this is a separate issue related to the GitHub OAuth App registered callback URL not matching — but the session ID issue was definitely the timeout.

## Fix
1. Increased `connectionTimeoutMillis` from `2000` → `10000` (10 seconds)
2. Added `ssl: { rejectUnauthorized: false }` when connecting to Supabase (required by pooler)

## Testing
- Verified DB connection works with correct credentials and SSL via `psycopg2`
- Supabase pooler confirmed reachable and responding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database connection reliability with improved timeout handling for better system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->