### PR TITLE
fix: catch getUserByAlias error in signIn callback to prevent OAuthCallback

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -55,8 +55,10 @@ export const authOptions = {
 			}
 			if (!dbUser && user.email) {
 				// then search based on aliases: ask if they want to merge accounts
+				let aliasLookupFailed = false;
 				const alias_users = await getUserByAlias(user.email).catch(err => {
 					console.error(`[signIn] getUserByAlias failed for ${user.email}`, err);
+					aliasLookupFailed = true;
 					return undefined;
 				});
 				if (alias_users?.length == 1) dbUser = alias_users[0];
@@ -65,6 +67,9 @@ export const authOptions = {
 					// Not allowing sign in when this happens
 					return false;
 				}
+				// If the DB lookup itself failed, skip createUser to avoid duplicate accounts.
+				// The sign-in will proceed; session callback will retry the lookup.
+				if (aliasLookupFailed) return true;
 			}
 
 			if (!dbUser) {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -55,7 +55,10 @@ export const authOptions = {
 			}
 			if (!dbUser && user.email) {
 				// then search based on aliases: ask if they want to merge accounts
-				const alias_users = await getUserByAlias(user.email);
+				const alias_users = await getUserByAlias(user.email).catch(err => {
+					console.error(`[signIn] getUserByAlias failed for ${user.email}`, err);
+					return undefined;
+				});
 				if (alias_users?.length == 1) dbUser = alias_users[0];
 				else if (alias_users && alias_users?.length > 1) {
 					// FIXME: show user the list of accounts and let them choose


### PR DESCRIPTION
## Root Cause

The `signIn` callback in `[...nextauth].ts` calls `getUserByAlias(user.email)` without any error handling:

```ts
const alias_users = await getUserByAlias(user.email); // no .catch()
```

If the Supabase DB connection times out or throws (which it was doing — 2s timeout, now 10s after PR #433), the unhandled exception propagates up through NextAuth's callback handler. NextAuth catches this internally and returns `error=OAuthCallback` to the browser.

This explains why a completely fresh browser still got `OAuthCallback` — it had nothing to do with stale cookies. The DB call was failing on every login attempt.

## Fix

Added `.catch()` to `getUserByAlias` in the `signIn` callback, matching the same error-handling pattern already used in the `session` callback. When the alias lookup fails, the code falls through to the `createUser` path (or the existing user is found via `getUserByProvider`), allowing login to complete.

## Related
- PR #433 increased DB connection timeout from 2s → 10s (reduces frequency of this error)
- This PR makes the error non-fatal when it does occur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in stability by adding resilient error handling around account lookup. Sign-in now continues when alias lookup errors occur, avoiding failed sign-ins and reducing risk of duplicate account creation. Users should see fewer interrupted sign-ins and more consistent authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->