### PR TITLE
fix: prevent Vercel CDN from caching auth-gated pages and session API routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -73,9 +73,11 @@ const nextConfig = {
 	async headers() {
 		return [
 			{
-				// Auth API routes: CORS headers + never cache (sessions must always be fresh)
+				// Auth API routes: full CORS + never cache (sessions must always be fresh)
+				// Access-Control-Allow-Origin must be explicit (not *) when credentials are true
 				source: "/api/auth/:path*",
 				headers: [
+					{ key: "Access-Control-Allow-Origin", value: "https://vibinex.com" },
 					{ key: "Access-Control-Allow-Credentials", value: "true" },
 					{
 						key: "Access-Control-Allow-Methods",
@@ -90,7 +92,7 @@ const nextConfig = {
 				],
 			},
 			{
-				// Other API routes: CORS headers only, no cache
+				// Other API routes: CORS headers + no cache (API responses are user-specific)
 				source: "/api/:path*",
 				headers: [
 					{ key: "Access-Control-Allow-Credentials", value: "true" },
@@ -114,8 +116,10 @@ const nextConfig = {
 				],
 			},
 			{
-				// Static assets and public pages: cache aggressively at CDN
-				source: "/((?!api|u).*)",
+				// Public pages and static assets: cache aggressively at CDN
+				// Use explicit exclusions rather than negative lookahead on single chars
+				// to avoid accidentally excluding future routes like /users, /updates, etc.
+				source: "/((?!api/)(?!u$).*)",
 				headers: [{
 					key: "Cache-Control",
 					value: "public, max-age=86400, s-maxage=86400, stale-while-revalidate",

--- a/next.config.js
+++ b/next.config.js
@@ -73,7 +73,24 @@ const nextConfig = {
 	async headers() {
 		return [
 			{
-				// Apply these headers to all static assets
+				// Auth API routes: CORS headers + never cache (sessions must always be fresh)
+				source: "/api/auth/:path*",
+				headers: [
+					{ key: "Access-Control-Allow-Credentials", value: "true" },
+					{
+						key: "Access-Control-Allow-Methods",
+						value: "GET,OPTIONS,PATCH,DELETE,POST,PUT",
+					},
+					{
+						key: "Access-Control-Allow-Headers",
+						value:
+							"X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization",
+					},
+					{ key: "Cache-Control", value: "private, no-store, no-cache, must-revalidate" },
+				],
+			},
+			{
+				// Other API routes: CORS headers only, no cache
 				source: "/api/:path*",
 				headers: [
 					{ key: "Access-Control-Allow-Credentials", value: "true" },
@@ -86,14 +103,23 @@ const nextConfig = {
 						value:
 							"X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization",
 					},
+					{ key: "Cache-Control", value: "private, no-store, no-cache, must-revalidate" },
 				],
-			}, {
-				source: "/(.*)",
+			},
+			{
+				// Auth-gated pages: never cache (login state must be checked fresh every request)
+				source: "/u",
+				headers: [
+					{ key: "Cache-Control", value: "private, no-store, no-cache, must-revalidate" },
+				],
+			},
+			{
+				// Static assets and public pages: cache aggressively at CDN
+				source: "/((?!api|u).*)",
 				headers: [{
 					key: "Cache-Control",
-					value: "max-age=86400, s-maxage=86400, stale-while-revalidate",
-				},
-				],
+					value: "public, max-age=86400, s-maxage=86400, stale-while-revalidate",
+				}],
 			},
 		];
 	},

--- a/pages/u.tsx
+++ b/pages/u.tsx
@@ -54,7 +54,7 @@ const Profile: NextPage<ProfileProps> = ({ sessionObj: session }) => {
 export const getServerSideProps: GetServerSideProps<ProfileProps> = async ({ req, res }) => {
 	res.setHeader(
 		'Cache-Control',
-		'public, s-maxage=1, stale-while-revalidate=10'
+		'private, no-store, no-cache, must-revalidate'
 	)
 	// check if user is logged in
 	const session = await getServerSession(req, res, authOptions);


### PR DESCRIPTION
## Root Cause

`next.config.js` had a catch-all `Cache-Control` header applying `s-maxage=86400` (24 hours CDN cache) to **all routes** — including `/api/auth/*` and `/u`.

Vercel CDN was caching the unauthenticated 302 redirect from `/u` → `/auth/signin`. Once cached, even authenticated users got the cached redirect for up to 24 hours, making login appear broken.

This is the same issue that caused problems in 2022 when first deploying to Vercel.

## Changes

- `/api/auth/*` — `Cache-Control: private, no-store` (session endpoints must never be cached)
- `/api/*` — `Cache-Control: private, no-store` (API responses are user-specific)
- `/u` page — `Cache-Control: private, no-store` (auth-gated, per-user, never cache)
- `/u` getServerSideProps — also sets `no-store` directly (belt and suspenders)
- All other routes — keep aggressive CDN caching unchanged (`public, s-maxage=86400`)

## Related PRs
- #433 — increased DB connection timeout
- #434 — fixed unhandled `getUserByAlias` error in signIn callback

Merge order: this PR + #434 together, then test from a fresh incognito window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized caching across API endpoints and site routes to ensure consistent content freshness.
  * Added explicit cross-origin support for authentication endpoints to improve interoperability with the auth flow.
  * Made user profile pages non-cacheable to prevent serving stale personal data.
  * Narrowed public caching to non-API, non-user routes for better performance and predictable stale-while-revalidate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->