### PR TITLE
chore: add eslint:recommended rules and VS Code ESLint extension

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "eslint:recommended"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["next/core-web-vitals", "eslint:recommended"]
+  "extends": ["next/core-web-vitals", "eslint:recommended"],
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-undef": "warn",
+    "no-mixed-spaces-and-tabs": "warn"
+  }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+      "dbaeumer.vscode-eslint"
+    ]
+  }
+  

--- a/components/LoginLogout.tsx
+++ b/components/LoginLogout.tsx
@@ -75,4 +75,4 @@ export default function LoginLogout() {
 			Login/Signup
 		</Button>
 	)
-};
+}

--- a/components/blog/ImageSlider.tsx
+++ b/components/blog/ImageSlider.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Fade } from "react-slideshow-image";
-import Image from "next/image";
+import NextImage from "next/image";
 import { getStrapiMedia } from "../../utils/blog/api-helpers";
 
 interface Image {
@@ -30,7 +30,7 @@ const Slideshow = ({ data }: { data: SlideShowProps }) => {
 		  }
 		  return (
 			<div key={fadeImage.attributes.url}>
-			  {imageUrl && <Image className="w-full h-96 object-cover rounded-lg" height={400} width={600} alt="alt text" src={imageUrl} />}
+			  {imageUrl && <NextImage className="w-full h-96 object-cover rounded-lg" height={400} width={600} alt="alt text" src={imageUrl} />}
 			</div>
 		  );
 		})}


### PR DESCRIPTION
Based on PR #249 by Tapish, rebased and updated.

## Changes
- Extends ESLint with `eslint:recommended` — all new violations are **warnings** (not errors) so CI stays green while the codebase gradually improves
- Adds `.vscode/extensions.json` recommending the ESLint extension to contributors
- Fixes 2 actual errors surfaced by the new rules:
  - `components/LoginLogout.tsx`: removed unnecessary trailing semicolon (`no-extra-semi`)
  - `components/blog/ImageSlider.tsx`: renamed `Image` import to `NextImage` to fix conflict with the local `Image` interface (`no-redeclare`)

## Why not just merge #249?
The original PR#249 also contained changes to `LoginLogout.tsx` and `pages/api/dpu/setup.ts` that conflict heavily with the current main (those files have been completely rewritten since Feb 2024). This PR cherry-picks only the ESLint config changes and adds the bug fixes, keeping things clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced ESLint configuration with additional rule coverage and explicit warning overrides
  * Added VSCode extension recommendation for improved development environment setup

* **Refactor**
  * Updated import handling in image components

* **Style**
  * Minor syntax adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->