### PR TITLE
docs: update server setup README — replace GCP cloud-sql-proxy with Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,44 +79,39 @@ Create a `.env.local` file in the root directory and add the following in it:
 ```bash
 # NextAuthJS
 NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=
+NEXTAUTH_SECRET=<any random string, e.g. output of: openssl rand -base64 32>
 
-# Github Login
+# Github Login — uses the "Vibinex Test" OAuth App
+# ⚠️  These are shared test credentials. Do not use them in production.
+#     Contact a maintainer if they stop working.
 GITHUB_CLIENT_ID=78eb181cacd859319797
 GITHUB_CLIENT_SECRET=c6efe816493a0b553ef20364134a3009b724b402
 
-# Bitbucket Login
+# Bitbucket Login (optional — create your own OAuth consumer at bitbucket.org)
 BITBUCKET_CLIENT_ID=
 BITBUCKET_CLIENT_SECRET=
 
 # Bitbucket OAuth consumer
 BITBUCKET_OAUTH_CLIENT_ID=
 
-# GitLab Login
+# GitLab Login (optional — create your own OAuth app at gitlab.com)
 GITLAB_CLIENT_ID=
 GITLAB_CLIENT_SECRET=
 
-# PostGreSQL Connection
-PGSQL_USER=postgres
-PGSQL_PASSWORD=vibi@test-pg
-PGSQL_HOST=127.0.0.1
-PGSQL_PORT=5432
-PGSQL_DATABASE=test-db
+# PostgreSQL Connection — Supabase test database
+# Contact a maintainer for the connection string, or use your own Supabase project.
+PGSQL_USER=
+PGSQL_PASSWORD=
+PGSQL_HOST=aws-0-ap-south-1.pooler.supabase.com
+PGSQL_PORT=6543
+PGSQL_DATABASE=postgres
 ```
 
-(TODO: Add steps for downloading the `cloud-sql-proxy` script)
+> **Note:** The database is hosted on Supabase. You will need the credentials from a maintainer to connect to the shared test database, or you can [create a free Supabase project](https://supabase.com) and run the schema migrations yourself.
 
-Now run the following command is a different terminal:
+The GitHub Client ID and Secret above are for the "Vibinex Test" OAuth App, which has `http://localhost:3000/api/auth/callback/github` registered as a callback URL — so GitHub login will work out of the box locally.
 
-```bash
-./cloud-sql-proxy --port 5432 vibi-test-394606:asia-south1:test-db --gcloud-auth
-```
-
-This will enable you to connect with our test database hosted on your localhost.
-
-The environment file also contains client ID and client secret for the Vibinex-Test OAuth App so that you can use the entire website locally
-by logging in using GitHub.
-You can create your own Bitbucket or GitLab OAuth consumers and add your client-id and client-secrets in the `.env.local` file to test them out.
+You can create your own Bitbucket or GitLab OAuth consumers and add your client-id and client-secrets in the `.env.local` file to test those providers.
 
 ### Running Unit Tests
 


### PR DESCRIPTION
## What changed

The `README.md` contributor setup section referenced `cloud-sql-proxy` pointing to a GCP project (`vibi-test-394606:asia-south1:test-db`) that no longer exists. Anyone following the old instructions would hit a dead end.

### Changes
- Removed all `cloud-sql-proxy` instructions (GCP test DB is gone)
- Updated `PGSQL_*` env vars to point to Supabase pooler (`aws-0-ap-south-1.pooler.supabase.com:6543`)
- Added note that contributors need DB credentials from a maintainer (or their own free Supabase project)
- Added warning comment on the shared test GitHub OAuth credentials
- Added note that the Vibinex Test OAuth App has `localhost:3000` callback registered
- Fixed `NEXTAUTH_SECRET` placeholder to include a helpful hint

## What was NOT changed
- The GitHub OAuth test credentials are kept — they are still valid and the callback URL is registered for localhost. Added a warning not to use them in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced test environment setup guidance with clearer OAuth configuration instructions for GitHub, Bitbucket, and GitLab.
  * Updated PostgreSQL database setup from local configuration to Supabase-hosted option.
  * Clarified authentication secret requirements and marked certain OAuth providers as optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->