### PR TITLE
fix: prevent shields.io badges from stretching full-width in markdown docs

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -196,7 +196,14 @@
 
 /* Images */
 .rich-text img {
-	@apply w-full object-cover rounded-xl my-6;
+	@apply max-w-full rounded-xl my-2;
+}
+
+/* Inline images (e.g. shields.io badges) — keep at natural size */
+.rich-text p img {
+	@apply inline-block max-w-full my-0 rounded-none;
+	height: auto;
+	vertical-align: middle;
 }
 
 /* Custom containers */


### PR DESCRIPTION
## Problem

The `.rich-text img` CSS rule had `w-full` (Tailwind), which forced all images to 100% container width. This made shields.io badges in the contributor docs (server-setup, dpu-setup, extension-setup READMEs) render absurdly large.

## Fix

- Top-level `img` rule: `w-full` → `max-w-full` so large content images stay responsive without forcing small ones to stretch
- Added `p img` rule for inline images: `inline-block` at natural dimensions, no border-radius, no extra margin — this handles badges which markdown always wraps in a `<p>` tag