### PR TITLE
feat: add view count and email subscribe to blog articles

### DIFF
--- a/components/blog/Post.tsx
+++ b/components/blog/Post.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { useState } from 'react';
-import { getStrapiMedia, formatDate } from '../../utils/blog/api-helpers';
+import { getStrapiMedia, getStrapiURL, formatDate } from '../../utils/blog/api-helpers';
 import { postRenderer } from '../../utils/blog/post-rendered';
 
 export interface Article {
@@ -44,14 +44,12 @@ const SubscribeForm: React.FC = () => {
 		if (!email) return;
 		setStatus('loading');
 		try {
-			const apiUrl = process.env.NEXT_PUBLIC_STRAPI_API_URL;
-			const token = process.env.NEXT_PUBLIC_STRAPI_API_TOKEN;
-			const res = await fetch(`${apiUrl}/api/lead-form-submissions`, {
+			// lead-form-submission has public create permission — no auth header needed
+			const url = getStrapiURL('/api/lead-form-submissions');
+			if (!url) throw new Error('Strapi URL not configured');
+			const res = await fetch(url, {
 				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Bearer ${token}`,
-				},
+				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ data: { email } }),
 			});
 			if (res.ok) {

--- a/components/blog/Post.tsx
+++ b/components/blog/Post.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useState } from 'react';
 import { getStrapiMedia, formatDate } from '../../utils/blog/api-helpers';
 import { postRenderer } from '../../utils/blog/post-rendered';
 
@@ -34,16 +35,78 @@ export interface Article {
 	};
 }
 
-const Post: React.FC<{ article: Article["attributes"] }> = ({ article }) => {
+const SubscribeForm: React.FC = () => {
+	const [email, setEmail] = useState('');
+	const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!email) return;
+		setStatus('loading');
+		try {
+			const apiUrl = process.env.NEXT_PUBLIC_STRAPI_API_URL;
+			const token = process.env.NEXT_PUBLIC_STRAPI_API_TOKEN;
+			const res = await fetch(`${apiUrl}/api/lead-form-submissions`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': `Bearer ${token}`,
+				},
+				body: JSON.stringify({ data: { email } }),
+			});
+			if (res.ok) {
+				setStatus('success');
+				setEmail('');
+			} else {
+				setStatus('error');
+			}
+		} catch {
+			setStatus('error');
+		}
+	};
+
+	return (
+		<div className="border border-border rounded-xl p-6 my-10 bg-primary text-center space-y-3">
+			<h3 className="text-xl font-semibold text-foreground">Get future essays in your inbox</h3>
+			<p className="text-muted-foreground text-sm">No noise — only when we publish something worth reading.</p>
+			{status === 'success' ? (
+				<p className="text-secondary font-medium">You&apos;re subscribed. Thank you!</p>
+			) : (
+				<form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2 justify-center">
+					<input
+						type="email"
+						placeholder="your@email.com"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
+						required
+						className="border border-border rounded-md px-4 py-2 text-sm bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-secondary w-full sm:w-72"
+					/>
+					<button
+						type="submit"
+						disabled={status === 'loading'}
+						className="bg-secondary text-white px-5 py-2 rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+					>
+						{status === 'loading' ? 'Subscribing…' : 'Subscribe'}
+					</button>
+				</form>
+			)}
+			{status === 'error' && (
+				<p className="text-red-500 text-sm">Something went wrong. Please try again.</p>
+			)}
+		</div>
+	);
+};
+
+const Post: React.FC<{ article: Article["attributes"], viewCount?: number | null }> = ({ article, viewCount }) => {
 	const { title, description, publishedAt, cover, authorsBio, blocks } = article;
 	const author = authorsBio.data?.attributes;
 	const imageUrl = getStrapiMedia(cover.data?.attributes.url);
 	const authorImgUrl = getStrapiMedia(authorsBio.data?.attributes.avatar.data.attributes.url);
 
-	if(imageUrl === null || authorImgUrl === null) {
+	if (imageUrl === null || authorImgUrl === null) {
 		console.error(`[blog/Post] imageUrl = ${imageUrl}, authorImgUrl = ${authorImgUrl}`);
 	}
-	// TODO - add placeholder image and/or author image
+
 	return (
 		<div className="space-y-8">
 			{imageUrl && (
@@ -56,7 +119,7 @@ const Post: React.FC<{ article: Article["attributes"] }> = ({ article }) => {
 				/>
 			)}
 			<div className="space-y-6">
-				<h1 className="leading-tight text-5xl font-bold ">{title}</h1>
+				<h1 className="leading-tight text-5xl font-bold">{title}</h1>
 				<div className="flex flex-col items-start justify-between w-full md:flex-row md:items-center text-primary-foreground">
 					<div className="flex items-center md:space-x-2">
 						{authorImgUrl && (
@@ -72,14 +135,20 @@ const Post: React.FC<{ article: Article["attributes"] }> = ({ article }) => {
 							{author?.name} • {formatDate(publishedAt)}
 						</p>
 					</div>
+					{viewCount !== null && viewCount !== undefined && (
+						<p className="text-sm text-muted-foreground mt-2 md:mt-0">
+							{viewCount.toLocaleString()} {viewCount === 1 ? 'read' : 'reads'}
+						</p>
+					)}
 				</div>
 			</div>
 
 			<div className="text-muted-foreground">
 				<p>{description}</p>
-
 				{blocks.map((section: any, index: number) => postRenderer(section, index))}
 			</div>
+
+			<SubscribeForm />
 		</div>
 	);
 }

--- a/pages/blog/[category]/[slug]/index.tsx
+++ b/pages/blog/[category]/[slug]/index.tsx
@@ -5,6 +5,7 @@ import Post, { Article } from '../../../../components/blog/Post';
 import Footer from '../../../../components/Footer';
 import RudderContext from '../../../../components/RudderContext';
 import { fetchAPI } from '../../../../utils/blog/fetch-api';
+import { getStrapiURL } from '../../../../utils/blog/api-helpers';
 import { getAndSetAnonymousIdFromLocalStorage } from '../../../../utils/rudderstack_initialize';
 import Navbar from '../../../../views/Navbar';
 
@@ -49,6 +50,7 @@ const PostRoute: NextPage = () => {
 	const router = useRouter();
 	const { rudderEventMethods } = useContext(RudderContext);
 
+	// Increment view count separately — keyed only to the slug so it fires exactly once per page load
 	useEffect(() => {
 		const slug = router.query.slug as string;
 		if (!slug) return;
@@ -57,19 +59,26 @@ const PostRoute: NextPage = () => {
 			const article = data.data[0];
 			setArticleInfo(article);
 
-			// Increment view count via the Strapi custom endpoint
-			const apiUrl = process.env.NEXT_PUBLIC_STRAPI_API_URL;
-			fetch(`${apiUrl}/api/articles/${article.id}/view`, { method: 'POST' })
+			// Increment view count — no auth header needed, endpoint is public
+			const viewUrl = getStrapiURL(`/api/articles/${article.id}/view`);
+			if (!viewUrl) return;
+			fetch(viewUrl, { method: 'POST' })
 				.then(r => r.json())
 				.then(d => { if (d.viewCount !== undefined) setViewCount(d.viewCount); })
 				.catch(err => console.error('[PostRoute] Failed to increment view count', err));
 		}).catch((error) => { console.error(
 			`[PostRoute] Unable to get post by slug ${slug}`, error);});
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [router.query.slug]);
 
+	// Track page visit separately — keyed to rudderEventMethods becoming available
+	useEffect(() => {
+		const slug = router.query.slug as string;
+		if (!slug || !rudderEventMethods) return;
 		const anonymousId = getAndSetAnonymousIdFromLocalStorage();
-		rudderEventMethods?.track("absent", "page-visit",
+		rudderEventMethods.track("absent", "page-visit",
 			{ type: "blog-article-page", category: router.query.category as string, slug }, anonymousId);
-	}, [rudderEventMethods, router]);
+	}, [rudderEventMethods, router.query.slug, router.query.category]);
 
 	if (!articleInfo) return <h2>Post not found</h2>;
 	return (

--- a/pages/blog/[category]/[slug]/index.tsx
+++ b/pages/blog/[category]/[slug]/index.tsx
@@ -45,18 +45,30 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 
 const PostRoute: NextPage = () => {
 	const [articleInfo, setArticleInfo] = useState<Article>();
+	const [viewCount, setViewCount] = useState<number | null>(null);
 	const router = useRouter();
 	const { rudderEventMethods } = useContext(RudderContext);
+
 	useEffect(() => {
-		// TODO: check that router.query.slug is a string
 		const slug = router.query.slug as string;
+		if (!slug) return;
+
 		getPostBySlug(slug).then((data) => {
-			setArticleInfo(data.data[0]);
+			const article = data.data[0];
+			setArticleInfo(article);
+
+			// Increment view count via the Strapi custom endpoint
+			const apiUrl = process.env.NEXT_PUBLIC_STRAPI_API_URL;
+			fetch(`${apiUrl}/api/articles/${article.id}/view`, { method: 'POST' })
+				.then(r => r.json())
+				.then(d => { if (d.viewCount !== undefined) setViewCount(d.viewCount); })
+				.catch(err => console.error('[PostRoute] Failed to increment view count', err));
 		}).catch((error) => { console.error(
 			`[PostRoute] Unable to get post by slug ${slug}`, error);});
+
 		const anonymousId = getAndSetAnonymousIdFromLocalStorage();
 		rudderEventMethods?.track("absent", "page-visit",
-			{ type: "blog-article-page", category: router.query.category as string, slug: slug}, anonymousId);
+			{ type: "blog-article-page", category: router.query.category as string, slug }, anonymousId);
 	}, [rudderEventMethods, router]);
 
 	if (!articleInfo) return <h2>Post not found</h2>;
@@ -65,7 +77,7 @@ const PostRoute: NextPage = () => {
 			<Navbar transparent={true} />
 			<div className='flex justify-center'>
 				<div className='mx-auto max-w-3xl px-6 lg:px-0'>
-					<Post article={articleInfo.attributes} />
+					<Post article={articleInfo.attributes} viewCount={viewCount} />
 				</div>
 			</div>
 			<Footer />


### PR DESCRIPTION
## What this adds

**View count:**
- New Strapi custom endpoint `POST /api/articles/:id/view` — increments server-side, no admin token needed from the client
- New `viewCount` field in the Article content type (integer, default 0)
- Article page calls the endpoint on load and shows "N reads" next to the author/date

**Email subscribe form:**
- Clean inline form at the bottom of every article
- POSTs email to Strapi `lead-form-submission` content type (already exists, already has public create permission)
- Success/error/loading states
- Copy: "Get future essays in your inbox / No noise — only when we publish something worth reading"

## What is NOT in this PR (follow-up work)
- Sending emails to subscribers when new articles are published (needs Strapi lifecycle hook + SendGrid integration — separate PR)
- Strapi admin view of subscribers is already available via the lead-form-submissions collection in Strapi admin

## Infrastructure change on the OCI VM
The `viewCount` field and custom `/view` endpoint were added directly to the Strapi instance on the OCI VM (schema + controller + route + rebuild). These changes need to be committed to the `vibinex/blog-backend` repo to stay in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Integrated a newsletter subscription form into blog posts, allowing readers to subscribe for updates directly from articles they're reading
- Added a view counter to blog articles that displays how many times each article has been read
- Implemented automatic view tracking to record each visit to an article

<!-- end of auto-generated comment: release notes by coderabbit.ai -->