### PR TITLE
fix: use NEXT_PUBLIC_CLARITY_ID so Clarity script loads client-side

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -50,7 +50,7 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
 						c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
 						t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
 						y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-					})(window, document, "clarity", "script", "${process.env.CLARITY_ID}");
+					})(window, document, "clarity", "script", "${process.env.NEXT_PUBLIC_CLARITY_ID}");
 					`}
 				</Script>
 				<Component {...pageProps} />


### PR DESCRIPTION
The `CLARITY_ID` env var was not `NEXT_PUBLIC_` prefixed, so Next.js pages router did not expose it to the browser bundle. The Clarity script rendered with `undefined` as the tag ID — meaning Clarity never initialised and the dashboard shows no data.

Fix: rename to `NEXT_PUBLIC_CLARITY_ID`. The new env var has been added to Vercel production + preview.