### PR TITLE
fix: add next-sitemap for robots.txt and sitemap.xml (fixes GSC indexing)

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -23,6 +23,8 @@ module.exports = {
           '/settings',
           '/repo',
           '/u',
+          '/chartDemo',
+          '/demo',
         ],
       },
     ],

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,33 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://vibinex.com',
+  generateRobotsTxt: true,
+  // Exclude private/auth/app routes from sitemap
+  exclude: [
+    '/auth/*',
+    '/api/*',
+    '/settings',
+    '/repo',
+    '/u',
+    '/chartDemo',
+    '/demo',
+  ],
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/api/',
+          '/auth/',
+          '/settings',
+          '/repo',
+          '/u',
+        ],
+      },
+    ],
+    additionalSitemaps: [
+      'https://vibinex.com/sitemap.xml',
+    ],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
 				"framer-motion": "^12.5.0",
 				"next": "13.3.1",
 				"next-auth": "4.22.1",
+				"next-sitemap": "^4.2.3",
 				"node-jose": "^2.2.0",
 				"pg": "^8.11.3",
 				"qs": "^6.12.1",
@@ -804,6 +805,12 @@
 			"engines": {
 				"node": ">=0.1.90"
 			}
+		},
+		"node_modules/@corex/deepmerge": {
+			"version": "4.0.43",
+			"resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+			"integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+			"license": "MIT"
 		},
 		"node_modules/@dabh/diagnostics": {
 			"version": "2.0.3",
@@ -1891,6 +1898,58 @@
 				"react": ">=16"
 			}
 		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+			"integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+			"integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+			"integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+			"integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
@@ -1901,6 +1960,19 @@
 			"optional": true,
 			"os": [
 				"linux"
+			]
+		},
+		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+			"integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
 			]
 		},
 		"node_modules/@next/env": {
@@ -6456,16 +6528,6 @@
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
 			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
 		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
-			}
-		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -7560,6 +7622,21 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -16056,6 +16133,39 @@
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
+		},
+		"node_modules/next-sitemap": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+			"integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+			"funding": [
+				{
+					"url": "https://github.com/iamvishnusankar/next-sitemap.git"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@corex/deepmerge": "^4.0.43",
+				"@next/env": "^13.4.3",
+				"fast-glob": "^3.2.12",
+				"minimist": "^1.2.8"
+			},
+			"bin": {
+				"next-sitemap": "bin/next-sitemap.mjs",
+				"next-sitemap-cjs": "bin/next-sitemap.cjs"
+			},
+			"engines": {
+				"node": ">=14.18"
+			},
+			"peerDependencies": {
+				"next": "*"
+			}
+		},
+		"node_modules/next-sitemap/node_modules/@next/env": {
+			"version": "13.5.11",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+			"integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+			"license": "MIT"
 		},
 		"node_modules/next/node_modules/postcss": {
 			"version": "8.4.14",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",
+		"postbuild": "next-sitemap",
 		"start": "next start",
 		"lint": "next lint",
 		"test": "jest",
@@ -50,6 +51,7 @@
 		"framer-motion": "^12.5.0",
 		"next": "13.3.1",
 		"next-auth": "4.22.1",
+		"next-sitemap": "^4.2.3",
 		"node-jose": "^2.2.0",
 		"pg": "^8.11.3",
 		"qs": "^6.12.1",


### PR DESCRIPTION
## Problem

Google Search Console has been flagging two critical indexing issues:
- `vibinex.com/robots.txt` → 404 (missing)
- `vibinex.com/sitemap.xml` → 404 (missing)

Google was crawling by link only, missing blog and dynamic pages.

## Solution

Add [`next-sitemap`](https://github.com/iamvishnusankar/next-sitemap) which auto-generates both files as part of the build.

## Changes

- **`package.json`**: add `next-sitemap` dependency + `"postbuild": "next-sitemap"` script
- **`next-sitemap.config.js`**: config with `siteUrl: 'https://vibinex.com'`, `generateRobotsTxt: true`, and exclusions for private/auth/API routes

### Excluded from sitemap (private/non-indexable routes):
`/auth/*`, `/api/*`, `/settings`, `/repo`, `/u`, `/chartDemo`, `/demo`

### All public routes are included:
`/`, `/blog/*`, `/docs/*`, `/pricing`, `/privacy`, `/terms`, `/about-us`

## After deploy

Submit `https://vibinex.com/sitemap.xml` in Google Search Console → Sitemaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented automated sitemap and robots.txt generation for improved search engine discoverability. Configured to appropriately exclude authentication, API, and internal routes from search engine indexing while allowing public content to be discoverable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vibinex/vibinex-server/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->