### PR TITLE
feat: add Postgres-backed DPU job queue

### DIFF
--- a/components/setup/DockerInstructions.tsx
+++ b/components/setup/DockerInstructions.tsx
@@ -13,19 +13,24 @@ interface DockerInstructionsProps {
 }
 
 const DockerInstructions: React.FC<DockerInstructionsProps> = ({ selectedInstallationType, selectedProvider, installId }) => {
+	const dpuImage = 'ghcr.io/vibinex/dpu:latest';
+	const serverUrl = typeof window === 'undefined' ? '<Vibinex server URL>' : window.location.origin;
 	const selfHostingCode = `
 docker run \\
 -v ~/.config/vibinex:/app/config \\
+-e DPU_QUEUE_TRANSPORT=http \\
 -e INSTALL_ID=${installId} \\
+-e SERVER_URL=${serverUrl} \\
+-e DPU_AUTH_TOKEN=<Your Vibinex DPU auth token> \\
 ${selectedProvider === 'github' && selectedInstallationType === 'pat' ? `-e PROVIDER=github \\
 -e GITHUB_PAT=<Your gh cli token> \\
-` : ''}asia.gcr.io/vibi-prod/dpu/dpu
+` : ''}${dpuImage}
   `;
 
 	const instructions = [
 		{
 			markdown: `1. **Pull the Vibinex DPU image**`,
-			command: `docker pull asia.gcr.io/vibi-prod/dpu/dpu`,
+			command: `docker pull ${dpuImage}`,
 		},
 		{
 			markdown: `2. **Create a config directory. This helps us restart the image from previous state in case of any issues**`,

--- a/components/setup/DockerInstructions.tsx
+++ b/components/setup/DockerInstructions.tsx
@@ -18,7 +18,7 @@ const DockerInstructions: React.FC<DockerInstructionsProps> = ({ selectedInstall
 	const selfHostingCode = `
 docker run \\
 -v ~/.config/vibinex:/app/config \\
--e DPU_QUEUE_TRANSPORT=http \\
+-e DPU_QUEUE_TRANSPORT=postgres \\
 -e INSTALL_ID=${installId} \\
 -e SERVER_URL=${serverUrl} \\
 -e DPU_AUTH_TOKEN=<Your Vibinex DPU auth token> \\

--- a/components/setup/HostingSelector.tsx
+++ b/components/setup/HostingSelector.tsx
@@ -8,7 +8,6 @@ interface HostingSelectorProps {
 
 const HostingSelector: React.FC<HostingSelectorProps> = ({ selectedHosting, setSelectedHosting }) => {
     const hostingOptions = [
-        { value: 'cloud', label: 'Vibinex Cloud' },
         { value: 'selfhosting', label: 'Self-hosting' },
     ];
 

--- a/components/setup/HostingSelector.tsx
+++ b/components/setup/HostingSelector.tsx
@@ -8,6 +8,7 @@ interface HostingSelectorProps {
 
 const HostingSelector: React.FC<HostingSelectorProps> = ({ selectedHosting, setSelectedHosting }) => {
     const hostingOptions = [
+        // { value: 'cloud', label: 'Vibinex Cloud' },
         { value: 'selfhosting', label: 'Self-hosting' },
     ];
 

--- a/pages/api/dpu/jobs/ack.ts
+++ b/pages/api/dpu/jobs/ack.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ackDpuJob } from '../../../../utils/db/dpuJobs';
+import { validateDpuAuth } from '../../../../utils/dpuAuth';
+
+export default async function ackHandler(req: NextApiRequest, res: NextApiResponse) {
+	if (req.method !== 'POST') {
+		res.status(405).json({ error: 'Method Not Allowed' });
+		return;
+	}
+	if (!validateDpuAuth(req, res)) return;
+
+	const { jobId, installationId } = req.body;
+	if (!jobId || !installationId) {
+		res.status(400).json({ error: 'jobId and installationId are required' });
+		return;
+	}
+
+	const acknowledged = await ackDpuJob(jobId.toString(), installationId.toString()).catch((err) => {
+		console.error('[ackHandler] Failed to acknowledge job', err);
+		return null;
+	});
+	if (acknowledged === null) {
+		res.status(500).json({ error: 'Unable to acknowledge job' });
+		return;
+	}
+	if (!acknowledged) {
+		res.status(404).json({ error: 'No processing job found' });
+		return;
+	}
+	res.status(200).json({ ok: true });
+}

--- a/pages/api/dpu/jobs/claim.ts
+++ b/pages/api/dpu/jobs/claim.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { claimDpuJobs } from '../../../../utils/db/dpuJobs';
+import { validateDpuAuth } from '../../../../utils/dpuAuth';
+
+const DEFAULT_LEASE_SECONDS = 300;
+const MAX_CLAIM_LIMIT = 10;
+
+export default async function claimHandler(req: NextApiRequest, res: NextApiResponse) {
+	if (req.method !== 'POST') {
+		res.status(405).json({ error: 'Method Not Allowed' });
+		return;
+	}
+	if (!validateDpuAuth(req, res)) return;
+
+	const { installationId, maxJobs, leaseSeconds } = req.body;
+	if (!installationId || typeof installationId !== 'string') {
+		res.status(400).json({ error: 'installationId is required' });
+		return;
+	}
+
+	const limit = Math.min(Number(maxJobs) || 1, MAX_CLAIM_LIMIT);
+	const lease = Number(leaseSeconds) || DEFAULT_LEASE_SECONDS;
+	const jobs = await claimDpuJobs(installationId, limit, lease).catch((err) => {
+		console.error('[claimHandler] Failed to claim jobs', err);
+		return null;
+	});
+	if (jobs === null) {
+		res.status(500).json({ error: 'Unable to claim jobs' });
+		return;
+	}
+
+	res.status(200).json({
+		jobs: jobs.map(job => ({
+			id: job.id.toString(),
+			msgType: job.msg_type,
+			payload: job.payload,
+			attempts: job.attempts,
+		})),
+	});
+}

--- a/pages/api/dpu/jobs/fail.ts
+++ b/pages/api/dpu/jobs/fail.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { failDpuJob } from '../../../../utils/db/dpuJobs';
+import { validateDpuAuth } from '../../../../utils/dpuAuth';
+
+export default async function failHandler(req: NextApiRequest, res: NextApiResponse) {
+	if (req.method !== 'POST') {
+		res.status(405).json({ error: 'Method Not Allowed' });
+		return;
+	}
+	if (!validateDpuAuth(req, res)) return;
+
+	const { jobId, installationId, error, retry } = req.body;
+	if (!jobId || !installationId) {
+		res.status(400).json({ error: 'jobId and installationId are required' });
+		return;
+	}
+
+	const failed = await failDpuJob(
+		jobId.toString(),
+		installationId.toString(),
+		typeof error === 'string' ? error : '',
+		retry !== false,
+	).catch((err) => {
+		console.error('[failHandler] Failed to mark job failed', err);
+		return null;
+	});
+	if (failed === null) {
+		res.status(500).json({ error: 'Unable to fail job' });
+		return;
+	}
+	if (!failed) {
+		res.status(404).json({ error: 'No processing job found' });
+		return;
+	}
+	res.status(200).json({ ok: true });
+}

--- a/pages/docs/setup/hosting.tsx
+++ b/pages/docs/setup/hosting.tsx
@@ -8,9 +8,7 @@ import LoadingOverlay from "../../../components/LoadingOverlay";
 import { RenderMarkdown } from "../../../components/RenderMarkdown";
 import RudderContext from "../../../components/RudderContext";
 import { useToast } from "../../../components/Toast/use-toast";
-import BuildInstruction from "../../../components/setup/BuildInstruction";
 import DockerInstructions from "../../../components/setup/DockerInstructions";
-import InstructionsToGeneratePersonalAccessToken from "../../../components/setup/InstructionsToGeneratePersonalAccessToken";
 import { getAuthUserId, getAuthUserName } from "../../../utils/auth";
 import { RepoProvider } from "../../../utils/providerAPI";
 import { getAndSetAnonymousIdFromLocalStorage } from "../../../utils/rudderstack_initialize";
@@ -69,10 +67,6 @@ Run our docker image locally or in your own cloud infrastructure. It will clone 
 ### Instructions to Setup DPU:
     `;
 
-    const cloudBuildExplainedMD = `## Host on Vibinex
-Too much hassle? Host DPU on Vibinex Cloud. The docker runs on Vibinex's infrastructure.
-We recommend this option for public repositories, it is the fastest way to set up.`;
-
     return (
         <div>
             <MainAppBar />
@@ -83,17 +77,7 @@ We recommend this option for public repositories, it is the fastest way to set u
                 <div className='sm:w-2/3 mx-auto mt-8 px-2 py-2 relative'>
                     <RenderMarkdown markdownText={hostingExplainedMD} />
                     <DockerInstructions selectedProvider={provider as RepoProvider} selectedInstallationType={installation as string} installId={installId as string} />
-                    {provider && provider === 'github' ?
-                        <div className='pb-16'>
-                            {installation && installation === 'pat' &&
-                                <InstructionsToGeneratePersonalAccessToken
-                                    selectedProvider={provider as RepoProvider}
-                                    selectedInstallationType={installation as string} />}
-                            <RenderMarkdown markdownText={cloudBuildExplainedMD} />
-                            <BuildInstruction selectedProvider={provider as RepoProvider} selectedInstallationType={installation as string} session={session} />
-                        </div>
-                        :
-                        <div className='pb-16'> </div>}
+                    <div className='pb-16'> </div>
                     <div className="flex mb-2 mr-2">
                         <Button onClick={() => window.history.back()} variant="outlined" className="px-4 py-2 flex-1 sm:flex-grow-0">
                             &laquo; Previous

--- a/pages/docs/setup/providerAppInstall.tsx
+++ b/pages/docs/setup/providerAppInstall.tsx
@@ -18,7 +18,7 @@ import DocsSideBar from '../../../views/docs/DocsSideBar';
 const ProviderAppInstall = ({ bitbucket_auth_url }: { bitbucket_auth_url: string }) => {
     const router = useRouter();
     const { provider, installation, ...restQueryParams } = router.query;
-    const hosting = "cloud";
+    const hosting = "selfhosting";
     const [session, setSession] = useState<Session | null>(null);
     const [theme, setTheme] = useState<Theme>('light');
     const [loading, setLoading] = useState(true);

--- a/utils/db/__tests__/dpuJobs.test.ts
+++ b/utils/db/__tests__/dpuJobs.test.ts
@@ -1,0 +1,64 @@
+import conn from '..';
+import { ackDpuJob, claimDpuJobs, enqueueDpuJob, ensureDpuJobsTable, failDpuJob } from '../dpuJobs';
+
+const INSTALLATION_ID = `jest-dpu-${Date.now()}`;
+
+describe('dpuJobs queue helpers', () => {
+	beforeAll(async () => {
+		await ensureDpuJobsTable();
+	});
+
+	afterEach(async () => {
+		await conn.query('DELETE FROM dpu_jobs WHERE installation_id = $1', [INSTALLATION_ID]);
+	});
+
+	afterAll(async () => {
+		await conn.end();
+	});
+
+	it('enqueues and claims jobs in FIFO order', async () => {
+		const firstJobId = await enqueueDpuJob(INSTALLATION_ID, 'manual_trigger', { pr_number: '1' });
+		const secondJobId = await enqueueDpuJob(INSTALLATION_ID, 'webhook_callback', { pr_number: '2' });
+
+		const jobs = await claimDpuJobs(INSTALLATION_ID, 2, 30);
+
+		expect(jobs.map(job => job.id.toString())).toEqual([firstJobId, secondJobId]);
+		expect(jobs.map(job => job.msg_type)).toEqual(['manual_trigger', 'webhook_callback']);
+		expect(jobs[0].status).toBe('processing');
+		expect(jobs[0].attempts).toBe(1);
+	});
+
+	it('acknowledges only processing jobs for the installation', async () => {
+		const jobId = await enqueueDpuJob(INSTALLATION_ID, 'PATSetup', { provider: 'github' });
+		expect(await ackDpuJob(jobId, INSTALLATION_ID)).toBe(false);
+
+		await claimDpuJobs(INSTALLATION_ID, 1, 30);
+		expect(await ackDpuJob(jobId, INSTALLATION_ID)).toBe(true);
+
+		const result = await conn.query('SELECT status FROM dpu_jobs WHERE id = $1', [jobId]);
+		expect(result.rows[0].status).toBe('completed');
+	});
+
+	it('returns failed jobs to pending when retrying', async () => {
+		const jobId = await enqueueDpuJob(INSTALLATION_ID, 'install_callback', { installation_code: '123' });
+		await claimDpuJobs(INSTALLATION_ID, 1, 30);
+
+		expect(await failDpuJob(jobId, INSTALLATION_ID, 'temporary failure')).toBe(true);
+
+		const jobs = await claimDpuJobs(INSTALLATION_ID, 1, 30);
+		expect(jobs).toHaveLength(1);
+		expect(jobs[0].id.toString()).toBe(jobId);
+		expect(jobs[0].attempts).toBe(2);
+	});
+
+	it('can mark failed jobs as terminal', async () => {
+		const jobId = await enqueueDpuJob(INSTALLATION_ID, 'install_callback', { installation_code: '123' });
+		await claimDpuJobs(INSTALLATION_ID, 1, 30);
+
+		expect(await failDpuJob(jobId, INSTALLATION_ID, 'permanent failure', false)).toBe(true);
+		expect(await claimDpuJobs(INSTALLATION_ID, 1, 30)).toEqual([]);
+
+		const result = await conn.query('SELECT status, last_error FROM dpu_jobs WHERE id = $1', [jobId]);
+		expect(result.rows[0]).toEqual({ status: 'failed', last_error: 'permanent failure' });
+	});
+});

--- a/utils/db/dpuJobs.ts
+++ b/utils/db/dpuJobs.ts
@@ -41,7 +41,13 @@ let schemaReady: Promise<void> | null = null;
 
 export async function ensureDpuJobsTable(): Promise<void> {
 	if (!schemaReady) {
-		schemaReady = conn.query(DPU_JOBS_SCHEMA_SQL).then(() => undefined);
+		schemaReady = conn.query(DPU_JOBS_SCHEMA_SQL).then(
+			() => undefined,
+			(err) => {
+				schemaReady = null;
+				throw err;
+			}
+		);
 	}
 	return schemaReady;
 }
@@ -97,7 +103,7 @@ export async function claimDpuJobs(
 		console.error('[claimDpuJobs] Failed to claim DPU jobs', { pg_query: query, installationId, limit, leaseSeconds }, err);
 		throw err;
 	});
-	return result.rows;
+	return result.rows.map(row => ({ ...row, id: row.id.toString() }));
 }
 
 export async function ackDpuJob(jobId: string, installationId: string): Promise<boolean> {

--- a/utils/db/dpuJobs.ts
+++ b/utils/db/dpuJobs.ts
@@ -1,0 +1,141 @@
+import conn from '.';
+import PubSubMessage from '../../types/PubSubMessage';
+
+export type DpuJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+export interface DpuJob {
+	id: string;
+	installation_id: string;
+	msg_type: string;
+	payload: PubSubMessage;
+	status: DpuJobStatus;
+	attempts: number;
+	locked_until: Date | null;
+	created_at: Date;
+	updated_at: Date;
+}
+
+export const DPU_JOBS_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS dpu_jobs (
+	id BIGSERIAL PRIMARY KEY,
+	installation_id TEXT NOT NULL,
+	msg_type TEXT NOT NULL,
+	payload JSONB NOT NULL,
+	status TEXT NOT NULL DEFAULT 'pending',
+	attempts INTEGER NOT NULL DEFAULT 0,
+	locked_until TIMESTAMPTZ,
+	claimed_at TIMESTAMPTZ,
+	completed_at TIMESTAMPTZ,
+	failed_at TIMESTAMPTZ,
+	last_error TEXT,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS dpu_jobs_claim_idx
+	ON dpu_jobs (installation_id, status, created_at)
+	WHERE status IN ('pending', 'processing');
+`;
+
+let schemaReady: Promise<void> | null = null;
+
+export async function ensureDpuJobsTable(): Promise<void> {
+	if (!schemaReady) {
+		schemaReady = conn.query(DPU_JOBS_SCHEMA_SQL).then(() => undefined);
+	}
+	return schemaReady;
+}
+
+export async function enqueueDpuJob(
+	installationId: string,
+	msgType: string,
+	payload: PubSubMessage,
+): Promise<string> {
+	await ensureDpuJobsTable();
+	const query = `
+		INSERT INTO dpu_jobs (installation_id, msg_type, payload)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`;
+	const result = await conn.query(query, [installationId, msgType, payload]).catch((err) => {
+		console.error('[enqueueDpuJob] Failed to insert DPU job', { pg_query: query, installationId, msgType }, err);
+		throw err;
+	});
+	return result.rows[0].id.toString();
+}
+
+export async function claimDpuJobs(
+	installationId: string,
+	limit = 1,
+	leaseSeconds = 300,
+): Promise<DpuJob[]> {
+	await ensureDpuJobsTable();
+	const query = `
+		WITH claimable AS (
+			SELECT id
+			FROM dpu_jobs
+			WHERE installation_id = $1
+				AND (
+					status = 'pending'
+					OR (status = 'processing' AND locked_until < NOW())
+				)
+			ORDER BY created_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE dpu_jobs
+		SET
+			status = 'processing',
+			attempts = attempts + 1,
+			claimed_at = NOW(),
+			locked_until = NOW() + ($3::TEXT || ' seconds')::INTERVAL,
+			updated_at = NOW()
+		WHERE id IN (SELECT id FROM claimable)
+		RETURNING *
+	`;
+	const result = await conn.query(query, [installationId, limit, leaseSeconds]).catch((err) => {
+		console.error('[claimDpuJobs] Failed to claim DPU jobs', { pg_query: query, installationId, limit, leaseSeconds }, err);
+		throw err;
+	});
+	return result.rows;
+}
+
+export async function ackDpuJob(jobId: string, installationId: string): Promise<boolean> {
+	await ensureDpuJobsTable();
+	const query = `
+		UPDATE dpu_jobs
+		SET status = 'completed',
+			completed_at = NOW(),
+			locked_until = NULL,
+			updated_at = NOW()
+		WHERE id = $1 AND installation_id = $2 AND status = 'processing'
+	`;
+	const result = await conn.query(query, [jobId, installationId]).catch((err) => {
+		console.error('[ackDpuJob] Failed to acknowledge DPU job', { pg_query: query, jobId, installationId }, err);
+		throw err;
+	});
+	return result.rowCount === 1;
+}
+
+export async function failDpuJob(
+	jobId: string,
+	installationId: string,
+	error: string,
+	retry = true,
+): Promise<boolean> {
+	await ensureDpuJobsTable();
+	const query = `
+		UPDATE dpu_jobs
+		SET status = CASE WHEN $3 THEN 'pending' ELSE 'failed' END,
+			failed_at = CASE WHEN $3 THEN failed_at ELSE NOW() END,
+			locked_until = NULL,
+			last_error = $4,
+			updated_at = NOW()
+		WHERE id = $1 AND installation_id = $2 AND status = 'processing'
+	`;
+	const result = await conn.query(query, [jobId, installationId, retry, error]).catch((err) => {
+		console.error('[failDpuJob] Failed to mark DPU job failed', { pg_query: query, jobId, installationId, retry }, err);
+		throw err;
+	});
+	return result.rowCount === 1;
+}

--- a/utils/dpuAuth.ts
+++ b/utils/dpuAuth.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export function validateDpuAuth(req: NextApiRequest, res: NextApiResponse): boolean {
+	const configuredToken = process.env.DPU_AUTH_TOKEN;
+	if (!configuredToken) {
+		console.error('[validateDpuAuth] DPU_AUTH_TOKEN is not configured');
+		res.status(500).json({ error: 'DPU auth is not configured' });
+		return false;
+	}
+	const authHeader = req.headers.authorization;
+	const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice('Bearer '.length) : undefined;
+	const headerToken = req.headers['x-dpu-auth-token'];
+	const providedToken = bearerToken ?? (Array.isArray(headerToken) ? headerToken[0] : headerToken);
+	if (providedToken !== configuredToken) {
+		res.status(401).json({ error: 'Unauthorized' });
+		return false;
+	}
+	return true;
+}

--- a/utils/dpuAuth.ts
+++ b/utils/dpuAuth.ts
@@ -1,4 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { timingSafeEqual } from 'crypto';
+
+function safeCompare(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
 
 export function validateDpuAuth(req: NextApiRequest, res: NextApiResponse): boolean {
 	const configuredToken = process.env.DPU_AUTH_TOKEN;
@@ -11,7 +17,7 @@ export function validateDpuAuth(req: NextApiRequest, res: NextApiResponse): bool
 	const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice('Bearer '.length) : undefined;
 	const headerToken = req.headers['x-dpu-auth-token'];
 	const providedToken = bearerToken ?? (Array.isArray(headerToken) ? headerToken[0] : headerToken);
-	if (providedToken !== configuredToken) {
+	if (!providedToken || !safeCompare(providedToken, configuredToken)) {
 		res.status(401).json({ error: 'Unauthorized' });
 		return false;
 	}

--- a/utils/pubsub/pubsubClient.ts
+++ b/utils/pubsub/pubsubClient.ts
@@ -1,11 +1,15 @@
 import { PubSub } from '@google-cloud/pubsub';
 import PubSubMessage from '../../types/PubSubMessage';
+import { enqueueDpuJob } from '../db/dpuJobs';
 
 // Set up authentication and initialize PubSub client
 const pubsub = new PubSub({ projectId: process.env.PROJECT_ID });
 
 
-export function publishMessage(topicName: string, data: PubSubMessage, msgType: string) {
+export async function publishMessage(topicName: string, data: PubSubMessage, msgType: string): Promise<string> {
+	if (process.env.DPU_QUEUE_TRANSPORT === 'postgres') {
+		return enqueueDpuJob(topicName, msgType, data);
+	}
 	const topic = pubsub.topic(topicName);
 	const message = {
 		data: Buffer.from(JSON.stringify(data)),
@@ -18,6 +22,9 @@ export function publishMessage(topicName: string, data: PubSubMessage, msgType: 
 }
 
 export async function createTopicNameInGcloud(topicName: string) {  
+	if (process.env.DPU_QUEUE_TRANSPORT === 'postgres') {
+		return topicName;
+	}
 	try {
 		const [topic] = await pubsub.createTopic(topicName);
 		console.log(`[createTopicNameInGcloud] Topic ${topic.name} created.`);


### PR DESCRIPTION
## Summary
- add a Postgres-backed DPU job queue with schema bootstrap, enqueue, claim, ack, and fail helpers
- expose authenticated DPU job APIs at /api/dpu/jobs/{claim,ack,fail}
- keep Pub/Sub compatibility behind DPU_QUEUE_TRANSPORT=pubsub|postgres
- point setup instructions to self-hosted GHCR DPU and remove the Vibinex Cloud setup CTA for now

## Paired PRs
- DPU transport: https://github.com/vibinex/vibi-dpu/pull/206
- Parent submodule sync: https://github.com/vibinex/vibinex/pull/3
 
## Verification
- npx tsc --noEmit --pretty false
- npm test -- --runInBand utils/db/__tests__/dpuJobs.test.ts using the test Supabase direct host override
- local Next smoke on :3001: seeded a dpu_jobs row, claimed through /api/dpu/jobs/claim, acked through /api/dpu/jobs/ack, verified status=completed attempts=1

## Notes
- The configured Supabase pooler user currently returns tenant/user not found; direct host works with the same test project credentials.
- next lint still fails on pre-existing utils/data.ts no-prototype-builtins plus repo-wide warnings; not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added job queue processing with claim/ack/fail flows and secure job authentication.
  * Added PostgreSQL-backed job transport option for self-hosted deployments.

* **Changes**
  * Docker setup updated to use the new image and compute server URL dynamically.
  * Self-hosting is now the primary deployment option; publish path adjusted for Postgres transport.

* **Documentation**
  * Hosting/setup docs updated to reflect self-hosting and simplified cloud instructions.

* **Tests**
  * New Jest tests covering job queue behaviors and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->