### PR TITLE
fix: stop logging the SendGrid API key

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -265,7 +265,6 @@ const sendSignupEmail = (userEmail: string, userName: string) => {
 </body>
 </html>
 	`;
-	console.debug(`[sendSignupEmail] SENDGRID_API_KEY = ${process.env.SENDGRID_API_KEY}`);
 	console.debug(`[sendSignupEmail] user email = ${userEmail}`);
 	const msg = {
 		to: userEmail, // recipient's email address


### PR DESCRIPTION
## Summary
- remove the debug log that printed the full SendGrid API key
- keep non-secret signup-email diagnostics intact

## Verification
- `npx tsc --noEmit --incremental false` passes on the current main checkout
- the change only removes a logging statement and introduces no runtime or type-level behavior

Closes #341
